### PR TITLE
Fix release date for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The following types of changes will be recorded in this file:
 
 - placeholder
 
-## [v0.1.0] - 2020-06-xx
+## [v0.1.0] - 2020-06-07
 
 Initial release!
 


### PR DESCRIPTION
This comes from rushing the release in order to make a deployment within a maintenance window (using a fixed version).