### PR TITLE
Attempt to fix GoDoc formatting

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -15,6 +15,7 @@ Monitor/validate certificates.
 FEATURES
 
 • Nagios plugin for monitoring certificates of certificate-enabled services
+
 • CLI tool for verifying certificates of certificate-enabled services or files
 
 USAGE - check_cert Nagios plugin


### PR DESCRIPTION
The "bullet points" were wrapping onto one line instead
of being separated into separate lines as a normal/supported
bulleted list would be. This commit adds an extra newline to
help force the items apart.