### PR TITLE
Apply intended SKIPSANSCHECK keyword validation

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -174,7 +174,7 @@ func main() {
 
 		// Check for special keyword, skip SANs entry checks if provided
 		firstSANsEntry := strings.ToLower(strings.TrimSpace(config.SANsEntries[0]))
-		if firstSANsEntry != SkipSANSCheckKeyword {
+		if firstSANsEntry != strings.ToLower(strings.TrimSpace(SkipSANSCheckKeyword)) {
 
 			if mismatched, err := certs.CheckSANsEntries(certChain[0], config.SANsEntries); err != nil {
 

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -178,7 +178,7 @@ func main() {
 
 		// Check for special keyword, skip SANs entry checks if provided
 		firstSANsEntry := strings.ToLower(strings.TrimSpace(config.SANsEntries[0]))
-		if firstSANsEntry != SkipSANSCheckKeyword {
+		if firstSANsEntry != strings.ToLower(strings.TrimSpace(SkipSANSCheckKeyword)) {
 
 			if mismatched, err := certs.CheckSANsEntries(certChain[0], config.SANsEntries); err != nil {
 


### PR DESCRIPTION
The prior check failed to take into the account the forced case-folding and whitespace-stripping applied to the first SANs entry value provided by the user.

fixes GH-17