### PR TITLE
Fix func doc comments stutter

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -39,7 +39,7 @@ func ConvertKeyIDToHexStr(keyID []byte) string {
 	return strings.Join(hexStrKeyID, ":")
 }
 
-// GetGetCertsFromFile is a helper function for retrieving a certificates
+// GetCertsFromFile is a helper function for retrieving a certificates
 // chain from a specified filename.
 func GetCertsFromFile(filename string) ([]*x509.Certificate, []byte, error) {
 
@@ -87,7 +87,7 @@ func GetCertsFromFile(filename string) ([]*x509.Certificate, []byte, error) {
 
 }
 
-// IsIsExpiredCert receives a x509 certificate and returns a boolean value
+// IsExpiredCert receives a x509 certificate and returns a boolean value
 // indicating whether the cert has expired.
 func IsExpiredCert(cert *x509.Certificate) bool {
 	return cert.NotAfter.Before(time.Now())


### PR DESCRIPTION
There may be other cases, but this commit corrects two doc
comments containing stuttering func names.

Backstory:

These cases were some that I missed after enabling VSCode's
"replace" setting for the for `editor.suggest.insertMode`
option. While I tried to catch each incomplete replacement,
these two (and likely other) cases slipped past my notice.

Unfortunately, I've found that this setting can be buggy
at times which results in replacement text being appended
instead of overwriting the existing content, leading to
cases like these.