### PR TITLE
Replace debug String() call with explicit format

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -293,7 +293,7 @@ func GenerateCertsReport(certChain []*x509.Certificate, ageCritical time.Time, a
 			certificate.Issuer,
 			ConvertKeyIDToHexStr(certificate.AuthorityKeyId),
 			certificate.SerialNumber,
-			certificate.NotAfter.String(),
+			certificate.NotAfter.Format("2006-01-02 15:04:05 -0700 MST"),
 			expiresText,
 		)
 


### PR DESCRIPTION
Caught this while auditing date comparisons for GH-32.

The net effect appears to be a NOOP in terms of output changes, but should hopefully prevent surprises if the String() method call changes in the future.