### PR TITLE
Use consistent & explicit validity date formatting

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -277,7 +277,7 @@ func main() {
 		"OK",
 		certs.ChainPosition(nextCertToExpire),
 		nextCertToExpire.Subject.CommonName,
-		nextCertToExpire.NotAfter.Format("2006-01-02 15:04:05 -0700 MST"),
+		nextCertToExpire.NotAfter.Format(certs.CertValidityDateLayout),
 	)
 	nagiosExitState.LongServiceOutput = certs.GenerateCertsReport(
 		certChain,

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -212,7 +212,7 @@ func main() {
 		"- FYI: %s cert %q expires next (on %s)",
 		certs.ChainPosition(nextCertToExpire),
 		nextCertToExpire.Subject.CommonName,
-		nextCertToExpire.NotAfter.Format("2006-01-02 15:04:05 -0700 MST"),
+		nextCertToExpire.NotAfter.Format(certs.CertValidityDateLayout),
 	)
 
 	textutils.PrintHeader("CERTIFICATES | CHAIN DETAILS")

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -20,6 +20,10 @@ import (
 	"github.com/atc0005/check-certs/internal/textutils"
 )
 
+// CertValidityDateLayout is the chosen date layout for displaying certificate
+// validity date/time values across our application.
+const CertValidityDateLayout string = "2006-01-02 15:04:05 -0700 MST"
+
 const (
 	certChainPositionLeaf         string = "leaf"
 	certChainPositionIntermediate string = "intermediate"
@@ -293,7 +297,7 @@ func GenerateCertsReport(certChain []*x509.Certificate, ageCritical time.Time, a
 			certificate.Issuer,
 			ConvertKeyIDToHexStr(certificate.AuthorityKeyId),
 			certificate.SerialNumber,
-			certificate.NotAfter.Format("2006-01-02 15:04:05 -0700 MST"),
+			certificate.NotAfter.Format(CertValidityDateLayout),
 			expiresText,
 		)
 


### PR DESCRIPTION
Create a shared const within our internal certs package and reference it everywhere we previously used a
hard-coded date layout.

refs GH-34