### PR TITLE
Update .gitignore patterns for plugin name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@
 scratch/
 
 # Ignore plugin name in its multiple (potential) variations
-check_cert
-check-cert
+/check_cert
+/check-cert
 
 /release_assets


### PR DESCRIPTION
Match on base repo path, not *anywhere* in the repo path