### PR TITLE
Enhance expiration threshold coverage

### DIFF
--- a/cmd/check_cert/checkresults.go
+++ b/cmd/check_cert/checkresults.go
@@ -44,6 +44,16 @@ type NagiosExitState struct {
 	// from the last service check.
 	LongServiceOutput string
 
+	// WarningThreshold is the value used to determine when the service check
+	// has crossed between an existing state into a WARNING state. This value
+	// is used for display purposes.
+	WarningThreshold string
+
+	// CriticalThreshold is the value used to determine when the service check
+	// has crossed between an existing state into a CRITICAL state. This value
+	// is used for display purposes.
+	CriticalThreshold string
+
 	// BrandingCallback is a function that is called before application
 	// termination to emit branding details at the end of the notification.
 	// See also NagiosExitCallBackFunc.
@@ -96,6 +106,11 @@ func (nes NagiosExitState) ReturnCheckResults() {
 		}
 
 		if nes.LongServiceOutput != "" {
+
+			fmt.Printf("\r\n**CERTIFICATE AGE THRESHOLDS**\r\n\r\n")
+
+			fmt.Printf("* %v\r\n", nes.CriticalThreshold)
+			fmt.Printf("* %v\r\n", nes.WarningThreshold)
 
 			fmt.Printf("\r\n**DETAILED INFO**\r\n")
 

--- a/cmd/check_cert/config.go
+++ b/cmd/check_cert/config.go
@@ -124,7 +124,7 @@ type Config struct {
 	// field as a WARNING state.
 	AgeWarning int
 
-	// AgeWarning is the number of days remaining before certificate
+	// AgeCritical is the number of days remaining before certificate
 	// expiration when this application will flag the NotAfter certificate
 	// field as a CRITICAL state.
 	AgeCritical int

--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -56,8 +56,20 @@ func main() {
 
 	// Use provided threshold values to calculate the expiration times that
 	// should trigger either a WARNING or CRITICAL state.
-	certsExpireAgeWarning := time.Now().Add(time.Hour * 24 * time.Duration(config.AgeWarning))
-	certsExpireAgeCritical := time.Now().Add(time.Hour * 24 * time.Duration(config.AgeCritical))
+	now := time.Now().UTC()
+	certsExpireAgeWarning := now.AddDate(0, 0, config.AgeWarning)
+	certsExpireAgeCritical := now.AddDate(0, 0, config.AgeCritical)
+
+	nagiosExitState.WarningThreshold = fmt.Sprintf(
+		"WARNING:\tExpires before %v (%d days)",
+		certsExpireAgeWarning.Format(certs.CertValidityDateLayout),
+		config.AgeWarning,
+	)
+	nagiosExitState.CriticalThreshold = fmt.Sprintf(
+		"CRITICAL:\tExpires before %v (%d days)",
+		certsExpireAgeCritical.Format(certs.CertValidityDateLayout),
+		config.AgeCritical,
+	)
 
 	// Note: Nagios doesn't look at stderr, only stdout. We have to make sure
 	// that only whatever output is meant for consumption is emitted to stdout

--- a/cmd/lscert/config.go
+++ b/cmd/lscert/config.go
@@ -139,7 +139,7 @@ type Config struct {
 	// field as a WARNING state.
 	AgeWarning int
 
-	// AgeWarning is the number of days remaining before certificate
+	// AgeCritical is the number of days remaining before certificate
 	// expiration when this application will flag the NotAfter certificate
 	// field as a CRITICAL state.
 	AgeCritical int

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -131,8 +131,21 @@ func main() {
 
 	certsTotal := len(certChain)
 
-	certsExpireAgeWarning := time.Now().Add(time.Hour * 24 * time.Duration(config.AgeWarning))
-	certsExpireAgeCritical := time.Now().Add(time.Hour * 24 * time.Duration(config.AgeCritical))
+	now := time.Now().UTC()
+	certsExpireAgeWarning := now.AddDate(0, 0, config.AgeWarning)
+	certsExpireAgeCritical := now.AddDate(0, 0, config.AgeCritical)
+
+	textutils.PrintHeader("CERTIFICATES | AGE THRESHOLDS")
+	fmt.Printf(
+		"\n- WARNING:\tExpires before %v (%d days)\n",
+		certsExpireAgeWarning.Format(certs.CertValidityDateLayout),
+		config.AgeWarning,
+	)
+	fmt.Printf(
+		"- CRITICAL:\tExpires before %v (%d days)\n",
+		certsExpireAgeCritical.Format(certs.CertValidityDateLayout),
+		config.AgeCritical,
+	)
 
 	textutils.PrintHeader("CERTIFICATES | SUMMARY")
 
@@ -195,6 +208,14 @@ func main() {
 		}
 	}
 
+	nextCertToExpire := certs.NextToExpire(certChain)
+	fmt.Printf(
+		"- FYI: %s cert %q expires next (on %s)\n",
+		certs.ChainPosition(nextCertToExpire),
+		nextCertToExpire.Subject.CommonName,
+		nextCertToExpire.NotAfter.Format(certs.CertValidityDateLayout),
+	)
+
 	if expired, count := certs.HasExpiredCert(certChain); expired {
 		fmt.Printf("- ERROR: %d certificates expired\n", count)
 	}
@@ -206,14 +227,6 @@ func main() {
 	); expiring {
 		fmt.Printf("- WARNING: %d certificates expiring soon\n", count)
 	}
-
-	nextCertToExpire := certs.NextToExpire(certChain)
-	fmt.Printf(
-		"- FYI: %s cert %q expires next (on %s)",
-		certs.ChainPosition(nextCertToExpire),
-		nextCertToExpire.Subject.CommonName,
-		nextCertToExpire.NotAfter.Format(certs.CertValidityDateLayout),
-	)
 
 	textutils.PrintHeader("CERTIFICATES | CHAIN DETAILS")
 

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -201,27 +201,28 @@ func FormattedExpiration(expireTime time.Time) string {
 func ExpirationStatus(cert *x509.Certificate, ageCritical time.Time, ageWarning time.Time) string {
 
 	var expiresText string
+	certExpiration := cert.NotAfter
 	switch {
-	case cert.NotAfter.Before(time.Now()):
+	case certExpiration.Before(time.Now()):
 		expiresText = fmt.Sprintf(
 			"[EXPIRED] %s",
-			FormattedExpiration(cert.NotAfter),
+			FormattedExpiration(certExpiration),
 		)
-	case cert.NotAfter.Before(ageCritical):
+	case certExpiration.Before(ageCritical):
 		expiresText = fmt.Sprintf(
 			"[CRITICAL] %s",
-			FormattedExpiration(cert.NotAfter),
+			FormattedExpiration(certExpiration),
 		)
-	case cert.NotAfter.Before(ageWarning):
+	case certExpiration.Before(ageWarning):
 		expiresText = fmt.Sprintf(
 			"[WARNING] %s",
-			FormattedExpiration(cert.NotAfter),
+			FormattedExpiration(certExpiration),
 		)
 	default:
 		expiresText = fmt.Sprintf(
 			// "[OK] | %s (%s)",
 			"[OK] %s",
-			FormattedExpiration(cert.NotAfter),
+			FormattedExpiration(certExpiration),
 		)
 
 	}


### PR DESCRIPTION
## PURPOSE

Better convey what thresholds were used to determine the current
state results

## CHANGES

- README
    - Remove reference to setting values in a config file (not yet
      implemented)
    - Add additional coverage for threshold logic
        - how it differs from the official `check_http` plugin
        - UTC values (previously local time)
        - emphasize that rounding is *not* used
    - Change flag descriptions for threshold values in an attempt to
      better explain the intent (coupled with the extra section for
      threshold calculations, this should hopefully be clearer)
- `lscert`
    - Fix struct field doc comment (referred to wrong field name)
    - Explicitly set UTC location for `now` variables
    - Add new output block to list WarningThreshold and
      CriticalThreshold formatted strings
        - expiration date thresholds in number of days
        - expiration date thresholds in specific dates/times
    - Move potential WARNING summary item just below the potential
      ERROR summary item, intentionally placing the FYI item last
- `check_cert`
    - Fix struct field doc comment (referred to wrong field name)
    - Add `NagiosExitState` struct fields
        - WarningThreshold
        - CriticalThreshold
    - Add new output block to list WarningThreshold and
      CriticalThreshold formatted strings
        - expiration date thresholds in number of days
        - expiration date thresholds in specific dates/times
        - when reviewing the email notification (ticket) or looking at
          the web UI, having this information available should help
          emphasize what values are used to determine the current
          service check state
- `internal/certs`
    - Update ExpirationStatus to (hopefully) read a little clearer for
      future troubleshooting sessions

## REFERENCES

- fixes GH-32