### PR TITLE
Server name: Use CN if set, otherwise first SANs

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -283,12 +283,22 @@ func main() {
 	// expiration date in the chain for quick reference however.
 	nextCertToExpire := certs.NextToExpire(certChain)
 
+	// Start by assuming that the CommonName is *not* blank
+	nextCertToExpireServerName := nextCertToExpire.Subject.CommonName
+
+	// but if it is, use the first SubjectAlterateName field in its place
+	if nextCertToExpire.Subject.CommonName == "" {
+		if len(nextCertToExpire.DNSNames[0]) > 0 {
+			nextCertToExpireServerName = nextCertToExpire.DNSNames[0]
+		}
+	}
+
 	nagiosExitState.LastError = nil
 	nagiosExitState.ServiceOutput = fmt.Sprintf(
 		"%s: %s cert %q expires next (on %s)",
 		"OK",
 		certs.ChainPosition(nextCertToExpire),
-		nextCertToExpire.Subject.CommonName,
+		nextCertToExpireServerName,
 		nextCertToExpire.NotAfter.Format(certs.CertValidityDateLayout),
 	)
 	nagiosExitState.LongServiceOutput = certs.GenerateCertsReport(

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -209,10 +209,21 @@ func main() {
 	}
 
 	nextCertToExpire := certs.NextToExpire(certChain)
+
+	// Start by assuming that the CommonName is *not* blank
+	nextCertToExpireServerName := nextCertToExpire.Subject.CommonName
+
+	// but if it is, use the first SubjectAlterateName field in its place
+	if nextCertToExpire.Subject.CommonName == "" {
+		if len(nextCertToExpire.DNSNames[0]) > 0 {
+			nextCertToExpireServerName = nextCertToExpire.DNSNames[0]
+		}
+	}
+
 	fmt.Printf(
 		"- FYI: %s cert %q expires next (on %s)\n",
 		certs.ChainPosition(nextCertToExpire),
-		nextCertToExpire.Subject.CommonName,
+		nextCertToExpireServerName,
 		nextCertToExpire.NotAfter.Format(certs.CertValidityDateLayout),
 	)
 


### PR DESCRIPTION
Fallback to first DNSName slice entry if Subject.CommonName
is not available from the certificate.

The assumption here is that *something* will be available in
the SANs list if the CommonName is empty. Further work may
be needed to guard against both fields being empty.

fixes GH-20