### PR TITLE
Fix gocritic comment formatting linting error

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -226,9 +226,7 @@ func FormattedExpiration(expireTime time.Time) string {
 	// simplified
 	hoursRemaining := math.Trunc(timeRemaining - (daysRemaining * 24))
 
-	//if hoursRemaining > 0 {
 	hoursRemainingStr = fmt.Sprintf("%dh", int64(hoursRemaining))
-	//}
 
 	formattedTimeRemainingStr = strings.Join([]string{
 		daysRemainingStr, hoursRemainingStr}, " ")


### PR DESCRIPTION
Minor issue with commented out code. I opted to remove the
comments instead of reformatting the lines (was not needed).