### PR TITLE
Restore newline for certs report

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -338,7 +338,7 @@ func GenerateCertsReport(certChain []*x509.Certificate, ageCritical time.Time, a
 				"%s\tIssuerKeyID: %v"+
 				"%s\tSerial: %s"+
 				"%s\tExpiration: %s"+
-				"%s\tStatus: %s%s",
+				"%s\tStatus: %s%s%s",
 			idx+1,
 			certsTotal,
 			certPosition,
@@ -358,6 +358,7 @@ func GenerateCertsReport(certChain []*x509.Certificate, ageCritical time.Time, a
 			certificate.NotAfter.Format(CertValidityDateLayout),
 			nagios.CheckOutputEOL,
 			expiresText,
+			nagios.CheckOutputEOL,
 			nagios.CheckOutputEOL,
 		)
 


### PR DESCRIPTION
That newline is needed to separate out the individual certificates in the chain.

refs GH-81