### PR TITLE
Add '-trimpath' build flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ VERSION 				= $(shell git describe --always --long --dirty)
 
 # The default `go build` process embeds debugging information. Building
 # without that debugging information reduces the binary size by around 28%.
-BUILDCMD				=	go build -mod=vendor -a -ldflags="-s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
+BUILDCMD				=	go build -mod=vendor -trimpath -a -ldflags="-s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
 GOCLEANCMD				=	go clean -mod=vendor ./...
 GITCLEANCMD				= 	git clean -xfd
 CHECKSUMCMD				=	sha256sum -b


### PR DESCRIPTION
Intended to help trim out unneeded details from misc output.

fixes GH-93