### PR TITLE
Makefile: Fix version tagging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,11 @@ SHELL = /bin/bash
 # Space-separated list of cmd/BINARY_NAME directories to build
 WHAT 					= check_cert lscert
 
-# TODO: This will need to be standardized across all cmd files in order to
-# work as intended.
-#
+
 # What package holds the "version" variable used in branding/version output?
 # VERSION_VAR_PKG			= $(shell go list .)
-# VERSION_VAR_PKG			= $(shell go list .)/internal/config
-VERSION_VAR_PKG			= main
+VERSION_VAR_PKG			= $(shell go list .)/internal/config
+# VERSION_VAR_PKG			= main
 
 OUTPUTDIR 				= release_assets
 


### PR DESCRIPTION
Update Makefile to reflect correct package for version
variable used to tag builds. This path changed with
the recent refactoring.

refs GH-108