### PR TITLE
Add back missing leading zero for serial numbers

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -251,7 +251,11 @@ func FormattedExpiration(expireTime time.Time) string {
 func FormatCertSerialNumber(sn *big.Int) string {
 
 	// convert serial number from native *bit.Int format to a hex string
-	snHexStr := sn.Text(16)
+	// snHexStr := sn.Text(16)
+	//
+	// use Sprintf hex formatting in order to retain leading zero (GH-114)
+	// credit: inspired by discussion on mozilla/tls-observatory#245
+	snHexStr := fmt.Sprintf("%X", sn.Bytes())
 
 	delimiterPosition := 2
 	delimiter := ":"


### PR DESCRIPTION
Use combination of `*big.Int` `Bytes` method and `fmt.Sprintf` hex formatting verb instead of `*big.Int` `Text(16)` method call in order to retain leading zero in hex formatted string.

fixes GH-114