### PR TITLE
Refactor, "fix" chain position identification

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -210,7 +210,7 @@ func main() {
 		firstSANsEntry := strings.ToLower(strings.TrimSpace(cfg.SANsEntries[0]))
 		if firstSANsEntry != strings.ToLower(strings.TrimSpace(config.SkipSANSCheckKeyword)) {
 
-			if mismatched, err := certs.CheckSANsEntries(certChain[0], cfg.SANsEntries); err != nil {
+			if mismatched, err := certs.CheckSANsEntries(certChain[0], certChain, cfg.SANsEntries); err != nil {
 
 				nagiosExitState.LastError = err
 

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -204,7 +204,7 @@ func main() {
 		firstSANsEntry := strings.ToLower(strings.TrimSpace(cfg.SANsEntries[0]))
 		if firstSANsEntry != strings.ToLower(strings.TrimSpace(config.SkipSANSCheckKeyword)) {
 
-			if mismatched, err := certs.CheckSANsEntries(certChain[0], cfg.SANsEntries); err != nil {
+			if mismatched, err := certs.CheckSANsEntries(certChain[0], certChain, cfg.SANsEntries); err != nil {
 
 				log.Debug().
 					Err(err).


### PR DESCRIPTION
- identify/label self-signed leaf certificates
- collapse `isRootCACert`, `isIntermediateCACert` and
  `isLeafCert` functions
- rework cert id logic to fallback to cert chain position
  for cases where other attributes (if even available)
  are not conclusive

fixes GH-127