### PR TITLE
Add IP range cert scanner prototype: certsum

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -84,3 +84,5 @@ jobs:
         run: |
           go build -v -mod=vendor ./cmd/check_cert
           go build -v -mod=vendor ./cmd/lscert
+          go build -v -mod=vendor ./cmd/fixsn
+          go build -v -mod=vendor ./cmd/certsum

--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,7 @@ scratch/
 
 # Ignore one-off CLI app builds
 /lscert
+/fixsn
+/certsum
 
 /release_assets

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@
 SHELL = /bin/bash
 
 # Space-separated list of cmd/BINARY_NAME directories to build
-WHAT 					= check_cert lscert
+WHAT 					= check_cert lscert certsum fixsn
 
 
 # What package holds the "version" variable used in branding/version output?

--- a/cmd/certsum/main.go
+++ b/cmd/certsum/main.go
@@ -1,0 +1,263 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	zlog "github.com/rs/zerolog/log"
+
+	"github.com/atc0005/check-certs/internal/certs"
+	"github.com/atc0005/check-certs/internal/config"
+	"github.com/atc0005/check-certs/internal/net"
+	"github.com/atc0005/check-certs/internal/textutils"
+)
+
+func main() {
+
+	// Setup configuration by parsing user-provided flags.
+	cfg, cfgErr := config.New(config.AppType{Scanner: true})
+	switch {
+	case errors.Is(cfgErr, config.ErrVersionRequested):
+		fmt.Println(config.Version())
+
+		return
+
+	case cfgErr != nil:
+		// We're using the standalone Err function from rs/zerolog/log as we
+		// do not have a working configuration.
+		zlog.Err(cfgErr).Msg("Error initializing application")
+
+		return
+	}
+
+	// Set common fields here so that we don't have to repeat them explicitly
+	// later. This will hopefully help to standardize the log messages to make
+	// them easier to search through later when troubleshooting.
+	log := cfg.Log.With().
+		Int("port_scan_timeout", int(cfg.TimeoutPortScan())).
+		Logger()
+
+	log.Debug().Msgf("CIDR range: %v", cfg.CIDRRange)
+
+	givenIPsList := make([]string, 0, 1024)
+	for _, ipRange := range cfg.CIDRRange {
+		ips, count, err := net.Hosts(ipRange)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to retrieve hosts from range")
+		}
+		log.Debug().
+			Int("ips_in_range", count).
+			Str("range", ipRange).
+			Msg("")
+		givenIPsList = append(givenIPsList, ips...)
+	}
+
+	fmt.Println("Total IPs from all ranges before deduping:", len(givenIPsList))
+
+	ipsList := textutils.DedupeList(givenIPsList)
+	fmt.Println("Total IPs from all ranges after deduping:", len(ipsList))
+
+	fmt.Println("Beginning scan of ports:", cfg.CertPorts())
+
+	var scanWG sync.WaitGroup
+	var collWG sync.WaitGroup
+
+	rateLimiter := make(chan struct{}, cfg.PortScanRateLimit)
+	results := make(chan net.PortCheckResult)
+	resultsIndex := make(net.PortCheckResultsIndex)
+
+	// Spin off scan results collector
+	collWG.Add(1)
+	go func(resultsIdx net.PortCheckResultsIndex, results <-chan net.PortCheckResult) {
+
+		log.Debug().Msg("starting collector routine")
+
+		// Receive check results, update index
+		for checkResult := range results {
+
+			log.Debug().Msgf(
+				"Adding results for %v to index",
+				checkResult.IPAddress.String(),
+			)
+
+			// grow the index of IP Address to port scan results for later review
+			resultsIdx[checkResult.IPAddress.String()] = append(
+				resultsIdx[checkResult.IPAddress.String()],
+				checkResult,
+			)
+		}
+
+		log.Debug().Msg("exiting collector routine")
+		collWG.Done()
+	}(resultsIndex, results)
+
+	for _, ip := range ipsList {
+
+		log.Debug().Msgf("Checking IP: %v", ip)
+
+		for _, port := range cfg.CertPorts() {
+
+			log.Debug().Msgf("Checking port %v for IP: %v", port, ip)
+
+			// indicate that we are launching a goroutine that will be tracked and
+			// reserve a spot in the (limited) channel
+			scanWG.Add(1)
+			rateLimiter <- struct{}{}
+
+			go func(
+				ipAddr string,
+				port int,
+				scanTimeout time.Duration,
+				resultsChan <-chan net.PortCheckResult,
+			) {
+
+				portState := net.CheckPort(ipAddr, port, scanTimeout)
+				if portState.Err != nil {
+					// TODO: Check specific error type to determine how to
+					// proceed. For now, we'll just emit the error and
+					// continue.
+					log.Error().
+						Str("host", ipAddr).
+						Int("port", port).
+						Err(portState.Err)
+				}
+
+				log.Debug().Msg("Sending result back on channel")
+
+				results <- portState
+
+				log.Debug().Msg("Sent result on channel, proceeding")
+
+				// if portState.Open {
+				// 	fmt.Printf("%v: port %v open\n", ipAddr, port)
+				// }
+
+				// indicate that we're done with this goroutine
+				scanWG.Done()
+
+				// release spot for next (held back) goroutine to run
+				<-rateLimiter
+
+			}(ip, port, cfg.TimeoutPortScan(), results)
+
+		}
+	}
+
+	// wait for all port scan attempts to complete
+	scanWG.Wait()
+
+	log.Debug().Msg("closing results channel")
+	// signal to collector that port scanning is complete
+	close(results)
+	log.Debug().Msg("closed results channel")
+
+	// wait for results collection goroutine to finish
+	collWG.Wait()
+
+	log.Debug().Msg("processing scan results")
+
+	var discoveredCertChains certs.DiscoveredCertChains
+
+	// TODO: refactor; use concurrency here instead of waiting for the port
+	// scan to complete before beginning cert analysis
+	fmt.Println("Completed port scan")
+	fmt.Println("Beginning certificate analysis")
+	for host, checkResults := range resultsIndex {
+
+		// unless user opted to show hosts with *all* closed ports, skip the
+		// host and continue to the next one
+		if !cfg.ShowHostsWithClosedPorts && !checkResults.HasOpenPort() {
+			continue
+		}
+
+		switch {
+		case cfg.ShowPortScanResults:
+			portSummary := func() string {
+				if checkResults.HasOpenPort() {
+					return checkResults.Summary()
+				}
+				return "None"
+			}()
+
+			// 192.168.1.2: [443: true, 636: false]
+			fmt.Printf("%s: [%s]\n", host, portSummary)
+		default:
+			fmt.Printf(".")
+		}
+
+		for _, result := range checkResults {
+			if result.Open {
+				var certFetchErr error
+				certChain, certFetchErr := net.GetCerts(
+					result.IPAddress.String(),
+					result.Port,
+					cfg.Timeout(),
+					log,
+				)
+				if certFetchErr != nil {
+					if !cfg.ShowPortScanResults {
+						// will need to insert a newline in-between error
+						// output if we're not showing port summary results
+						fmt.Println()
+					}
+					log.Error().
+						Err(certFetchErr).
+						Str("host", result.IPAddress.String()).
+						Int("port", result.Port).
+						Msg("error fetching certificates chain")
+					// os.Exit(1)
+					// TODO: Decide whether fetch errors are critical or just warning level
+					continue
+				}
+
+				// do something with certChain
+				discoveredCertChains = append(
+					discoveredCertChains, certs.DiscoveredCertChain{
+						Host:  result.IPAddress.String(),
+						Port:  result.Port,
+						Certs: certChain,
+					})
+			}
+
+		}
+	}
+
+	if !cfg.ShowPortScanResults {
+		// will need to insert a newline before showing cert summary
+		// output if we did not include port summary results as we checked
+		// examined certs earlier
+		fmt.Println()
+	}
+
+	fmt.Println("Completed certificate analysis")
+
+	fmt.Printf("\nResults:\n\n")
+
+	switch {
+	case cfg.ShowOverview:
+		printSummaryHighLevel(
+			cfg.ShowHostsWithValidCerts,
+			discoveredCertChains,
+			cfg.AgeCritical,
+			cfg.AgeWarning,
+		)
+
+	default:
+		printSummaryDetailedLevel(
+			cfg.ShowValidCerts,
+			discoveredCertChains,
+			cfg.AgeCritical,
+			cfg.AgeWarning,
+		)
+	}
+
+}

--- a/cmd/certsum/summary.go
+++ b/cmd/certsum/summary.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/atc0005/check-certs/internal/certs"
+)
+
+func printSummaryHighLevel(
+	showAllHosts bool,
+	discoveredChains certs.DiscoveredCertChains,
+	ageCritical int,
+	ageWarning int,
+) {
+
+	tw := tabwriter.NewWriter(os.Stdout, 8, 8, 4, '\t', 0)
+
+	// Header row in output
+	fmt.Fprintf(tw,
+		"IP Address\tPort\tSubject or SANs\tStatus\tChain Summary\tSerial\n")
+
+	// Separator row
+	fmt.Fprintln(tw,
+		"---\t---\t---\t---\t---\t---")
+
+	now := time.Now().UTC()
+	certsExpireAgeWarning := now.AddDate(0, 0, ageWarning)
+	certsExpireAgeCritical := now.AddDate(0, 0, ageCritical)
+
+	for _, certChain := range discoveredChains {
+
+		hasExpiredCert := certs.HasExpiredCert(certChain.Certs)
+		hasExpiringCert := certs.HasExpiringCert(
+			certChain.Certs,
+			certsExpireAgeCritical,
+			certsExpireAgeWarning,
+		)
+
+		var statusIcon string
+		switch {
+		case hasExpiredCert || hasExpiringCert:
+			statusIcon = "\xE2\x9B\x94 (!!)"
+		default:
+			statusIcon = "\xE2\x9C\x85 (OK)"
+		}
+
+		// Skip listing IP Addresses with certs without issues *unless*
+		// specifically requested.
+		if !hasExpiredCert && !hasExpiringCert && !showAllHosts {
+			continue
+		}
+
+		name := certChain.Certs[0].Subject.CommonName
+		if name == "" {
+			name = strings.Join(certChain.Certs[0].DNSNames, ", ")
+		}
+
+		fmt.Fprintf(
+			tw,
+			"%v\t%v\t%v\t%s\t%v\t%v\n",
+			certChain.Host,
+			certChain.Port,
+			name,
+			statusIcon,
+			certs.ChainSummary(
+				certChain.Certs,
+				certsExpireAgeCritical,
+				certsExpireAgeWarning,
+			).Summary,
+			certs.FormatCertSerialNumber(certChain.Certs[0].SerialNumber),
+		)
+
+	}
+
+	fmt.Fprintln(tw)
+	if err := tw.Flush(); err != nil {
+		log.Printf(
+			"error occurred flushing tabwriter: %v",
+			err,
+		)
+	}
+}
+
+func printSummaryDetailedLevel(
+	showAllCerts bool,
+	discoveredChains certs.DiscoveredCertChains,
+	ageCritical int,
+	ageWarning int,
+) {
+
+	tw := tabwriter.NewWriter(os.Stdout, 8, 8, 4, '\t', 0)
+
+	// Header row in output
+	fmt.Fprintf(tw,
+		"IP Address\tPort\tSubject or SANs\tStatus (Type)\tSummary\tSerial\n")
+
+	// Separator row
+	fmt.Fprintln(tw,
+		"---\t---\t---\t---\t---\t---")
+
+	now := time.Now().UTC()
+	certsExpireAgeWarning := now.AddDate(0, 0, ageWarning)
+	certsExpireAgeCritical := now.AddDate(0, 0, ageCritical)
+
+	for _, certChain := range discoveredChains {
+		for _, cert := range certChain.Certs {
+
+			isExpiredCert := certs.IsExpiredCert(cert)
+			isExpiringCert := certs.IsExpiringCert(
+				cert,
+				certsExpireAgeCritical,
+				certsExpireAgeWarning,
+			)
+
+			// Skip listing Certificates in the chain which are valid *unless*
+			// specifically requested.
+			if !isExpiredCert && !isExpiringCert && !showAllCerts {
+				continue
+			}
+
+			var statusIcon string
+			switch {
+			case isExpiredCert || isExpiringCert:
+				statusIcon = "\xE2\x9B\x94"
+			default:
+				statusIcon = "\xE2\x9C\x85"
+			}
+
+			name := cert.Subject.CommonName
+			if name == "" {
+				name = strings.Join(cert.DNSNames, ", ")
+			}
+
+			fmt.Fprintf(
+				tw,
+				"%v\t%v\t%v\t%s (%s)\t%v\t%v\n",
+				certChain.Host,
+				certChain.Port,
+				name,
+				statusIcon,
+				certs.ChainPosition(cert, certChain.Certs),
+				certs.ExpirationStatus(cert, certsExpireAgeCritical, certsExpireAgeWarning),
+				certs.FormatCertSerialNumber(cert.SerialNumber),
+			)
+		}
+
+	}
+
+	fmt.Fprintln(tw)
+	if err := tw.Flush(); err != nil {
+		log.Printf(
+			"error occurred flushing tabwriter: %v",
+			err,
+		)
+	}
+}

--- a/cmd/fixsn/main.go
+++ b/cmd/fixsn/main.go
@@ -1,0 +1,59 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Purpose:
+//
+// A small CLI app used to convert a given base 10 number into a base 16,
+// colon delimited hex string representing a certificate serial number. Prior
+// releases of this project improperly displayed serial numbers as base 10
+// values instead of base 16, colon delimited hex strings. Using this tool can
+// be useful for one-off conversion of older values to the proper format
+// (e.g., a certs list maintained in documentation).
+
+package main
+
+import (
+	"fmt"
+	"math/big"
+	"os"
+	"regexp"
+
+	"github.com/atc0005/check-certs/internal/certs"
+)
+
+func main() {
+
+	// https://stackoverflow.com/a/58957206/903870
+	var digitCheck = regexp.MustCompile(`^[0-9]+$`)
+
+	// expected output: FD:6F:3E:24:98:C2:5B:1D:08:00:00:00:00:47:F0:33
+	sampleExpectedInput := "336872288293767042001244177974291853363"
+
+	serialNumber := new(big.Int)
+
+	if len(os.Args) < 2 {
+		fmt.Println("Error: Missing serial number (in base 10 format)")
+		fmt.Println("Example expected input:", sampleExpectedInput)
+		os.Exit(1)
+	}
+
+	if !digitCheck.MatchString(os.Args[1]) {
+		fmt.Println("Error: Invalid serial number (in base 10 format)")
+		fmt.Println("Example expected input:", sampleExpectedInput)
+		os.Exit(1)
+	}
+
+	_, ok := serialNumber.SetString(os.Args[1], 10)
+	if !ok {
+		fmt.Println("Error: Failed to parse provided serial number (in base 10 format)")
+		fmt.Println("Example expected input:", sampleExpectedInput)
+		os.Exit(1)
+	}
+
+	fmt.Println(certs.FormatCertSerialNumber(serialNumber))
+
+}

--- a/doc.go
+++ b/doc.go
@@ -18,6 +18,8 @@ FEATURES
 
 • CLI tool for verifying certificates of certificate-enabled services or files
 
+• CLI tool for generating summary of discovered certificates from given IP ranges and ports
+
 USAGE
 
 See our main README for supported settings and examples.

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -19,18 +19,27 @@ const myAppURL string = "https://github.com/atc0005/check-cert"
 const SkipSANSCheckKeyword string = "SKIPSANSCHECKS"
 
 const (
-	versionFlagHelp               string = "Whether to display application version and then immediately exit application."
-	sansEntriesFlagHelp           string = "One or many Subject Alternate Names (SANs) expected for the certificate used by the remote service. If provided, this list of comma-separated (optional) values is required for the certificate to pass validation. If the case-insensitive SKIPSANSCHECKS keyword is provided this validation will be skipped, effectively turning the use of this flag into a NOOP."
-	dnsNameFlagHelp               string = "The fully-qualified domain name of the remote system to be used for hostname verification. This option can be used for cases where make the initial connection using a name or IP not associated with the certificate."
-	logLevelFlagHelp              string = "Sets log level to one of disabled, panic, fatal, error, warn, info, debug or trace."
-	serverFlagHelp                string = "The fully-qualified domain name or IP Address of the remote system whose cert(s) will be monitored. The value provided will be validated against the Common Name and Subject Alternate Names fields."
-	portFlagHelp                  string = "TCP port of the remote certificate-enabled service. This is usually 443 (HTTPS) or 636 (LDAPS)."
-	timeoutFlagHelp               string = "Timeout value in seconds allowed before the connection attempt to a remote certificate-enabled service is abandoned and an error returned."
-	emitCertTextFlagHelp          string = "Toggles emission of x509 TLS certificates in an OpenSSL-inspired text format. This output is disabled by default."
-	filenameFlagHelp              string = "Fully-qualified path to a file containing one or more certificates."
-	certExpireAgeWarningFlagHelp  string = "The number of days remaining before certificate expiration when this application will will flag the NotAfter certificate field as a WARNING state."
-	certExpireAgeCriticalFlagHelp string = "The number of days remaining before certificate expiration when this application will will flag the NotAfter certificate field as a CRITICAL state."
-	brandingFlagHelp              string = "Toggles emission of branding details with plugin status details. This output is disabled by default."
+	versionFlagHelp                  string = "Whether to display application version and then immediately exit application."
+	sansEntriesFlagHelp              string = "One or many Subject Alternate Names (SANs) expected for the certificate used by the remote service. If provided, this list of comma-separated (optional) values is required for the certificate to pass validation. If the case-insensitive SKIPSANSCHECKS keyword is provided this validation will be skipped, effectively turning the use of this flag into a NOOP."
+	dnsNameFlagHelp                  string = "The fully-qualified domain name of the remote system to be used for hostname verification. This option can be used for cases where make the initial connection using a name or IP not associated with the certificate."
+	logLevelFlagHelp                 string = "Sets log level to one of disabled, panic, fatal, error, warn, info, debug or trace."
+	serverFlagHelp                   string = "The fully-qualified domain name or IP Address of the remote system whose cert(s) will be monitored. The value provided will be validated against the Common Name and Subject Alternate Names fields."
+	cidrRangeFlagHelp                string = "List of comma-separated CIDR IP ranges to scan for certificates."
+	portFlagHelp                     string = "TCP port of the remote certificate-enabled service. This is usually 443 (HTTPS) or 636 (LDAPS)."
+	portsListFlagHelp                string = "List of comma-separated TCP ports to check for certificates. If not specified, the list defaults to 443 only."
+	timeoutFlagHelp                  string = "Timeout value in seconds allowed before a connection attempt to a remote certificate-enabled service (in order to retrieve the certificate) is abandoned and an error returned."
+	timeoutPortScanFlagHelp          string = "The number of milliseconds before a connection attempt during a port scan is abandoned and an error returned. This timeout value is separate from the general `timeout` value used when retrieving certificates. This setting is used specifically to quickly determine port state as part of bulk operations where speed is crucial."
+	portScanRateLimitFlagHelp        string = "Maximum concurrent port scans. Remaining port scans are queued until an existing scan completes."
+	emitCertTextFlagHelp             string = "Toggles emission of x509 TLS certificates in an OpenSSL-inspired text format. This output is disabled by default."
+	filenameFlagHelp                 string = "Fully-qualified path to a file containing one or more certificates."
+	certExpireAgeWarningFlagHelp     string = "The number of days remaining before certificate expiration when this application will will flag the NotAfter certificate field as a WARNING state."
+	certExpireAgeCriticalFlagHelp    string = "The number of days remaining before certificate expiration when this application will will flag the NotAfter certificate field as a CRITICAL state."
+	brandingFlagHelp                 string = "Toggles emission of branding details with plugin status details. This output is disabled by default."
+	showHostsWithClosedPortsFlagHelp string = "Toggles listing all host port scan results, even for hosts without any specified ports in an open state."
+	showHostsWithValidCertsFlagHelp  string = "Toggles listing all cert check results in overview output, even for hosts with valid certificates."
+	showValidCertsFlagHelp           string = "Toggles listing all certificates in output summary, even certificates which have passed all validity checks."
+	showOverviewFlagHelp             string = "Toggles summary output view from detailed to overview."
+	showPortScanResultsFlagHelp      string = "Toggles listing host port scan results."
 )
 
 // Default flag settings if not overridden by user input
@@ -50,4 +59,40 @@ const (
 
 	// Default CRITICAL threshold is 15 days
 	defaultCertExpireAgeCritical int = 15
+
+	// Default timeout (in milliseconds) used when testing whether a TCP port
+	// is open or closed.
+	defaultPortScanTimeout = 200
+
+	defaultPortScanRateLimit int = 100
+
+	// For the "scanner", this flag value is required.
+	// defaultCIDRRange string = ""
+	// FIXME
+	// Update: this is handled due to the underlying slice type which can
+	// either be nil or contain content
+
+	// the sole entry in the list of ports to be checked by the scanner
+	defaultPortsListEntry int = 443
+
+	// list port open/close scan results (false == exclude)
+	defaultShowPortScanResults bool = false
+
+	// list hosts with specified ports in closed state (false == exclude)
+	defaultShowHostsWithClosedPorts bool = false
+
+	// list hosts with valid certs (false == exclude)
+	defaultShowHostsWithValidCerts bool = false
+
+	// list valid certs in summary output (false == exclude)
+	defaultShowValidCerts bool = false
+
+	// show overview instead of detailed view (false == show detailed view)
+	defaultShowOverview bool = false
+)
+
+const (
+	appTypePlugin    string = "plugin"
+	appTypeInspecter string = "inspecter"
+	appTypeScanner   string = "scanner"
 )

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -10,22 +10,70 @@ package config
 import "flag"
 
 // handleFlagsConfig handles toggling the exposure of specific configuration
-// flags to the user. This behavior is controlled via a boolean value
-// initially set by each cmd. If enabled, a smaller subset of flags specific
-// to cmd binaries are exposed, otherwise the set of flags specific to a
-// Nagios plugin are exposed and processed.
-func (c *Config) handleFlagsConfig(isPlugin bool) {
+// flags to the user. This behavior is controlled via the specified
+// application type as set by each cmd. Based on the application type, a
+// smaller subset of flags specific to each type are exposed along with a set
+// common to all application types.
+func (c *Config) handleFlagsConfig(appType AppType) {
 
-	// Flags specific to one or the other
+	// Flags specific to one application type or the other
 	switch {
-	case isPlugin:
+	case appType.Plugin:
 		flag.BoolVar(&c.EmitBranding, "branding", defaultBranding, brandingFlagHelp)
-	case !isPlugin:
+
+		flag.StringVar(&c.Server, "s", defaultServer, serverFlagHelp+" (shorthand)")
+		flag.StringVar(&c.Server, "server", defaultServer, serverFlagHelp)
+
+		flag.StringVar(&c.DNSName, "dn", defaultDNSName, dnsNameFlagHelp)
+		flag.StringVar(&c.DNSName, "dns-name", defaultDNSName, dnsNameFlagHelp)
+
+		flag.IntVar(&c.Port, "p", defaultPort, portFlagHelp+" (shorthand)")
+		flag.IntVar(&c.Port, "port", defaultPort, portFlagHelp)
+
+	case appType.Inspecter:
 		flag.StringVar(&c.Filename, "filename", defaultFilename, filenameFlagHelp)
 		flag.BoolVar(&c.EmitCertText, "text", defaultEmitCertText, emitCertTextFlagHelp)
+
+		flag.StringVar(&c.Server, "s", defaultServer, serverFlagHelp+" (shorthand)")
+		flag.StringVar(&c.Server, "server", defaultServer, serverFlagHelp)
+
+		flag.StringVar(&c.DNSName, "dn", defaultDNSName, dnsNameFlagHelp)
+		flag.StringVar(&c.DNSName, "dns-name", defaultDNSName, dnsNameFlagHelp)
+
+		flag.IntVar(&c.Port, "p", defaultPort, portFlagHelp+" (shorthand)")
+		flag.IntVar(&c.Port, "port", defaultPort, portFlagHelp)
+
+	case appType.Scanner:
+		flag.IntVar(&c.timeoutPortScan, "scan-timeout", defaultPortScanTimeout, timeoutPortScanFlagHelp)
+		flag.IntVar(&c.timeoutPortScan, "st", defaultPortScanTimeout, timeoutPortScanFlagHelp+" (shorthand)")
+
+		flag.Var(&c.CIDRRange, "cidr-ip-range", cidrRangeFlagHelp)
+		flag.Var(&c.CIDRRange, "cir", cidrRangeFlagHelp+" (shorthand)")
+
+		flag.IntVar(&c.PortScanRateLimit, "scan-rate-limit", defaultPortScanRateLimit, portScanRateLimitFlagHelp)
+		flag.IntVar(&c.PortScanRateLimit, "srl", defaultPortScanRateLimit, portScanRateLimitFlagHelp+" (shorthand)")
+
+		flag.Var(&c.portsList, "ports", portsListFlagHelp)
+		flag.Var(&c.portsList, "p", portsListFlagHelp+" (shorthand)")
+
+		flag.BoolVar(&c.ShowPortScanResults, "show-port-scan-results", defaultShowPortScanResults, showPortScanResultsFlagHelp)
+		flag.BoolVar(&c.ShowPortScanResults, "spsr", defaultShowPortScanResults, showPortScanResultsFlagHelp+" (shorthand)")
+
+		flag.BoolVar(&c.ShowHostsWithClosedPorts, "show-closed-ports", defaultShowHostsWithClosedPorts, showHostsWithClosedPortsFlagHelp)
+		flag.BoolVar(&c.ShowHostsWithClosedPorts, "scp", defaultShowHostsWithClosedPorts, showHostsWithClosedPortsFlagHelp+" (shorthand)")
+
+		flag.BoolVar(&c.ShowHostsWithValidCerts, "show-hosts-with-valid-certs", defaultShowHostsWithValidCerts, showHostsWithValidCertsFlagHelp)
+		flag.BoolVar(&c.ShowHostsWithValidCerts, "shwvc", defaultShowHostsWithValidCerts, showHostsWithValidCertsFlagHelp+" (shorthand)")
+
+		flag.BoolVar(&c.ShowValidCerts, "show-valid-certs", defaultShowValidCerts, showValidCertsFlagHelp)
+		flag.BoolVar(&c.ShowValidCerts, "svc", defaultShowValidCerts, showValidCertsFlagHelp+" (shorthand)")
+
+		flag.BoolVar(&c.ShowOverview, "show-overview", defaultShowOverview, showOverviewFlagHelp)
+		flag.BoolVar(&c.ShowOverview, "so", defaultShowOverview, showOverviewFlagHelp+" (shorthand)")
+
 	}
 
-	// Shared flags
+	// Shared flags for all application type
 
 	flag.Var(&c.SANsEntries, "se", sansEntriesFlagHelp)
 	flag.Var(&c.SANsEntries, "sans-entries", sansEntriesFlagHelp)
@@ -36,17 +84,8 @@ func (c *Config) handleFlagsConfig(isPlugin bool) {
 	flag.IntVar(&c.AgeCritical, "c", defaultCertExpireAgeCritical, certExpireAgeCriticalFlagHelp)
 	flag.IntVar(&c.AgeCritical, "age-critical", defaultCertExpireAgeCritical, certExpireAgeCriticalFlagHelp)
 
-	flag.StringVar(&c.Server, "s", defaultServer, serverFlagHelp)
-	flag.StringVar(&c.Server, "server", defaultServer, serverFlagHelp)
-
-	flag.StringVar(&c.DNSName, "dn", defaultDNSName, dnsNameFlagHelp)
-	flag.StringVar(&c.DNSName, "dns-name", defaultDNSName, dnsNameFlagHelp)
-
-	flag.IntVar(&c.Port, "p", defaultPort, portFlagHelp)
-	flag.IntVar(&c.Port, "port", defaultPort, portFlagHelp)
-
-	flag.IntVar(&c.Timeout, "t", defaultTimeout, timeoutFlagHelp)
-	flag.IntVar(&c.Timeout, "timeout", defaultTimeout, timeoutFlagHelp)
+	flag.IntVar(&c.timeout, "t", defaultTimeout, timeoutFlagHelp)
+	flag.IntVar(&c.timeout, "timeout", defaultTimeout, timeoutFlagHelp)
 
 	flag.StringVar(&c.LoggingLevel, "ll", defaultLogLevel, logLevelFlagHelp)
 	flag.StringVar(&c.LoggingLevel, "log-level", defaultLogLevel, logLevelFlagHelp)

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -1,0 +1,34 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package config
+
+import "time"
+
+// Timeout converts the user-specified connection timeout value in
+// seconds to an appropriate time duration value for use with setting
+// net.Dial timeout.
+func (c Config) Timeout() time.Duration {
+	return time.Duration(c.timeout) * time.Second
+}
+
+// TimeoutPortScan converts the user-specified port scan timeout value in
+// milliseconds to an appropriate time duration value for use with setting
+// net.Dial timeout.
+func (c Config) TimeoutPortScan() time.Duration {
+	return time.Duration(c.timeoutPortScan) * time.Millisecond
+}
+
+// CertPorts returns the user-specified list of ports to check for
+// certificates or the default value if not specified.
+func (c Config) CertPorts() []int {
+	if c.portsList != nil {
+		return c.portsList
+	}
+
+	return []int{defaultPortsListEntry}
+}

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -93,19 +93,27 @@ func setLoggingLevel(logLevel string) error {
 
 // setupLogging is responsible for configuring logging settings for this
 // application
-func (c *Config) setupLogging(isPlugin bool) error {
+func (c *Config) setupLogging(appType AppType) error {
 
 	var output *os.File
+	var appDescription string
 
 	switch {
-	case isPlugin:
+	case appType.Inspecter:
+		// CLI app logging goes to stdout
+		output = os.Stdout
+		appDescription = appTypeInspecter
+
+	case appType.Plugin:
 		// plugin logging goes to stderr to prevent mixing in with stdout output
 		// intended for the Nagios console
 		output = os.Stderr
+		appDescription = appTypePlugin
 
-	case !isPlugin:
+	case appType.Scanner:
 		// CLI app logging goes to stdout
 		output = os.Stdout
+		appDescription = appTypeScanner
 	}
 
 	// We set some common fields here so that we don't have to repeat them
@@ -116,9 +124,8 @@ func (c *Config) setupLogging(isPlugin bool) error {
 	c.Log = zerolog.New(output).With().Caller().
 		Str("version", Version()).
 		Str("logging_level", c.LoggingLevel).
-		Bool("is_plugin", isPlugin).
-		Str("server", c.Server).
-		Int("port", c.Port).
+		Str("app_type", appDescription).
+		Str("cert_check_timeout", c.Timeout().String()).
 		Int("age_warning", c.AgeWarning).
 		Int("age_critical", c.AgeCritical).
 		Logger()

--- a/internal/net/doc.go
+++ b/internal/net/doc.go
@@ -1,0 +1,10 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Package net provides helper functions for network related operations such
+// as port scanning or subnet slicing.
+package net

--- a/internal/net/net.go
+++ b/internal/net/net.go
@@ -1,0 +1,204 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package net
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// PortCheckResult indicates whether a TCP port is open and what error (if
+// any) occurred checking the port.
+type PortCheckResult struct {
+	IPAddress net.IPAddr
+	Port      int
+	Open      bool
+	Err       error
+}
+
+// PortCheckResults is a collection of PortCheckResult intended for bulk
+// operations such as filtering or generating summaries.
+type PortCheckResults []PortCheckResult
+
+// PortCheckResultsIndex maps the results slice from scan attempts against a
+// specified list of ports to an IP Address associated with scanned ports.
+type PortCheckResultsIndex map[string]PortCheckResults
+
+// HasOpenPort indicates whether at least one specified port was found to be
+// open for a scanned host.
+func (rs PortCheckResults) HasOpenPort() bool {
+	for _, r := range rs {
+		if r.Open {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Summary generates a one-line summary of port check results.
+func (rs PortCheckResults) Summary() string {
+
+	sx := make([]string, len(rs))
+
+	for i, result := range rs {
+		sx[i] = fmt.Sprintf("%v: %v", result.Port, result.Open)
+	}
+
+	return strings.Join(sx, ", ")
+
+}
+
+// CheckPort checks whether a specified TCP port is open. Any errors
+// encountered are returned along with the port status.
+func CheckPort(host string, port int, timeout time.Duration) PortCheckResult {
+
+	// TODO: Make sure to set PortCheckResult.Err to an error which indicates
+	// the severity of the issue. For example, failing to close the port is
+	// different than failing to establish a connection. We can then check
+	// this "severity" at the call site to determine whether to fail the scan
+	// or keep going with a WARNING status for the specific host.
+
+	ipAddress := net.ParseIP(host)
+
+	conn, connErr := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), timeout)
+	if connErr != nil {
+		return PortCheckResult{
+			IPAddress: net.IPAddr{IP: ipAddress},
+			Port:      port,
+			Open:      false,
+			Err:       connErr,
+		}
+	}
+
+	closeErr := conn.Close()
+	if closeErr != nil {
+		return PortCheckResult{
+			IPAddress: net.IPAddr{IP: ipAddress},
+			Port:      port,
+			Open:      true,
+			Err:       closeErr,
+		}
+	}
+
+	return PortCheckResult{
+		IPAddress: net.IPAddr{IP: ipAddress},
+		Port:      port,
+		Open:      true,
+		Err:       nil,
+	}
+
+}
+
+// Hosts converts a CIDR network pattern into a slice of hosts within that
+// network, the total count of hosts and an error if any occurred.
+//
+// https://stackoverflow.com/questions/60540465/go-how-to-list-all-ips-in-a-network
+// https://play.golang.org/p/fe-F2k6prlA
+// https://gist.github.com/kotakanbe/d3059af990252ba89a82
+func Hosts(cidr string) ([]string, int, error) {
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var ips []string
+	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
+		ips = append(ips, ip.String())
+	}
+
+	// remove network address and broadcast address
+	lenIPs := len(ips)
+	switch {
+	case lenIPs < 2:
+		return ips, lenIPs, nil
+
+	default:
+		return ips[1 : len(ips)-1], lenIPs - 2, nil
+	}
+}
+
+// inc is a helper function used to increment a given IP Address (presumably
+// to the next available IP Address).
+//
+// https://stackoverflow.com/questions/60540465/go-how-to-list-all-ips-in-a-network
+// https://play.golang.org/p/fe-F2k6prlA
+// https://gist.github.com/kotakanbe/d3059af990252ba89a82
+func inc(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
+	}
+}
+
+// GetCerts retrieves and returns the certificate chain from the specified
+// host & port or an error if one occurs. Enforced certificate verification is
+// intentionally disabled in order to successfully retrieve and examine all
+// certificates in the certificate chain.
+func GetCerts(server string, port int, timeout time.Duration, logger zerolog.Logger) ([]*x509.Certificate, error) {
+
+	var certChain []*x509.Certificate
+
+	logger = logger.With().
+		Str("server", server).
+		Int("port", port).
+		Str("timeout", timeout.String()).
+		Logger()
+
+	logger.Debug().Msg("Connecting to remote server")
+	tlsConfig := tls.Config{
+		// Permit insecure connection.
+		//
+		// This is needed so that we can examine not only valid certificates,
+		// but certs that are expired, self-signed or having other properties
+		// which make them invalid. This is also needed so that we can examine
+		// not only the initial certificate, but others in the chain also.
+		// This allows us to flag any intermediate or root certs which may
+		// also be expired.
+		//
+		// Ignore security (gosec) linting warnings re this choice.
+		// nolint:gosec
+		InsecureSkipVerify: true,
+	}
+
+	// Create custom dialer with user-specified timeout value
+	dialer := &net.Dialer{
+		Timeout: timeout,
+	}
+
+	serverConnStr := fmt.Sprintf("%s:%d", server, port)
+	conn, connErr := tls.DialWithDialer(dialer, "tcp", serverConnStr, &tlsConfig)
+	if connErr != nil {
+		// logger.Error().Err(connErr).Msgf("error connecting to server")
+		return nil, fmt.Errorf("error connecting to server: %w", connErr)
+	}
+	logger.Debug().Msg("Connected")
+
+	// grab certificate chain as presented by remote peer
+	certChain = conn.ConnectionState().PeerCertificates
+	logger.Debug().Msg("Retrieved certificate chain")
+
+	// close connection once we're finished with it
+	if err := conn.Close(); err != nil {
+		errMsg := "error closing connection to server"
+		logger.Error().Err(err).Msg(errMsg)
+
+		return nil, fmt.Errorf("%s: %w", errMsg, err)
+	}
+	logger.Debug().Msg("Successfully closed connection to server")
+
+	return certChain, nil
+}

--- a/internal/textutils/textutils.go
+++ b/internal/textutils/textutils.go
@@ -9,6 +9,7 @@ package textutils
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -21,6 +22,36 @@ func InList(needle string, haystack []string) bool {
 		}
 	}
 	return false
+}
+
+// DedupeList returns a copy of a provided string slice with all duplicate
+// entries removed.
+// FIXME: Is there already a standard library version of this functionality?
+func DedupeList(list []string) []string {
+
+	// preallocate at least as much space as the original
+	newList := make([]string, 0, len(list))
+	uniqueItems := make(map[string]struct{})
+
+	// build a map of unique list entries
+	for _, item := range list {
+		uniqueItems[item] = struct{}{}
+	}
+
+	// generate a new, deduped list from the map
+	for key := range uniqueItems {
+		newList = append(newList, key)
+	}
+	return newList
+}
+
+// IntSliceToStringSlice converts a slice of integers to a slice of string.
+func IntSliceToStringSlice(ix []int) []string {
+	sx := make([]string, len(ix))
+	for i, v := range ix {
+		sx[i] = strconv.Itoa(v)
+	}
+	return sx
 }
 
 // LowerCaseStringSlice is a helper function to convert all provided string
@@ -82,4 +113,13 @@ func InsertDelimiter(s string, delimiter string, pos int) string {
 	}
 
 	return delimitedStr
+}
+
+// BytesToDelimitedHexStr converts a byte slice to a delimited hex string.
+func BytesToDelimitedHexStr(bx []byte, delimiter string) string {
+	hexStr := make([]string, 0, len(bx))
+	for _, v := range bx {
+		hexStr = append(hexStr, fmt.Sprintf("%X", v))
+	}
+	return strings.Join(hexStr, delimiter)
 }


### PR DESCRIPTION
Initial prototype to scan one or more given IP ranges and
and report overview of certificate status. This is a "MVP"
build and considered to be of "alpha" level quality.
Many of the exposed flags, help text and summary output
is subject to change significantly in later releases.

Performance is so-so, with only the initial port scanning
handled in a concurrent fashion; the actual cert retrieval
process is handled one host/port at a time. Unsurprisingly,
this does not scale well for larger IP ranges.

Additionally, specifying partial/non-CIDR IP ranges is not
tested or supported at this time, though it is possible
to specify multiple CIDR ranges for evaluation.

This build also allows for filtering "OK" status hosts and
certs to either increase or reduce the amount of information
provided. Two summary modes are also provided in order to
control the level of detail in the provided summary.

Other changes include updating flag handling based on a
specified "app type", one of `Inspecter`, `Plugin` or
`Scanner` and refactoring of shared functionality to reduce
code duplication.

Lastly, a sweep of existing documenation has been made to fix
minor issues and provide clarification between existing
functionality and new. Much work remains to be done.

fixes GH-103