### PR TITLE
Rename internal/net to internal/netutils

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/atc0005/check-certs/internal/certs"
 	"github.com/atc0005/check-certs/internal/config"
-	"github.com/atc0005/check-certs/internal/net"
+	"github.com/atc0005/check-certs/internal/netutils"
 	"github.com/atc0005/go-nagios"
 )
 
@@ -82,7 +82,7 @@ func main() {
 		Int("port", cfg.Port).
 		Logger()
 
-	certChain, certFetchErr := net.GetCerts(cfg.Server, cfg.Port, cfg.Timeout(), log)
+	certChain, certFetchErr := netutils.GetCerts(cfg.Server, cfg.Port, cfg.Timeout(), log)
 	if certFetchErr != nil {
 		log.Error().Err(certFetchErr).Msg(
 			"error fetching certificates chain")

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/atc0005/check-certs/internal/certs"
 	"github.com/atc0005/check-certs/internal/config"
-	"github.com/atc0005/check-certs/internal/net"
+	"github.com/atc0005/check-certs/internal/netutils"
 	"github.com/atc0005/check-certs/internal/textutils"
 	"github.com/atc0005/go-nagios"
 )
@@ -81,7 +81,7 @@ func main() {
 	case cfg.Server != "":
 
 		var certFetchErr error
-		certChain, certFetchErr = net.GetCerts(cfg.Server, cfg.Port, cfg.Timeout(), log)
+		certChain, certFetchErr = netutils.GetCerts(cfg.Server, cfg.Port, cfg.Timeout(), log)
 		if certFetchErr != nil {
 			log.Error().Err(certFetchErr).Msg(
 				"error fetching certificates chain")

--- a/internal/netutils/doc.go
+++ b/internal/netutils/doc.go
@@ -5,6 +5,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root for
 // full license information.
 
-// Package net provides helper functions for network related operations such
-// as port scanning or subnet slicing.
-package net
+// Package netutils provides helper functions for network related operations
+// such as port scanning or subnet slicing.
+package netutils

--- a/internal/netutils/net.go
+++ b/internal/netutils/net.go
@@ -5,7 +5,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root for
 // full license information.
 
-package net
+package netutils
 
 import (
 	"crypto/tls"


### PR DESCRIPTION
Avoid future collisions with `net` standard library package.

fixes GH-140