### PR TITLE
certsum: Initial support of partial IP ranges

### DIFF
--- a/cmd/certsum/main.go
+++ b/cmd/certsum/main.go
@@ -46,21 +46,8 @@ func main() {
 		Int("port_scan_timeout", int(cfg.TimeoutPortScan())).
 		Logger()
 
-	log.Debug().Msgf("CIDR range: %v", cfg.CIDRRange)
-
-	givenIPsList := make([]string, 0, 1024)
-	for _, ipRange := range cfg.CIDRRange {
-		ips, count, err := netutils.Hosts(ipRange)
-		if err != nil {
-			log.Error().Err(err).Msg("failed to retrieve hosts from range")
-		}
-		log.Debug().
-			Int("ips_in_range", count).
-			Str("range", ipRange).
-			Msg("")
-		givenIPsList = append(givenIPsList, ips...)
-	}
-
+	givenIPsList := cfg.IPAddresses()
+	log.Debug().Msgf("IP Addresses: %v", givenIPsList)
 	fmt.Println("Total IPs from all ranges before deduping:", len(givenIPsList))
 
 	ipsList := textutils.DedupeList(givenIPsList)

--- a/cmd/range/main.go
+++ b/cmd/range/main.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/atc0005/check-certs/internal/netutils"
+)
+
+// Purpose: Proof of concept for new partial range syntax. Based heavily off
+// of nmap's "octet range addressing" syntax.
+
+// TODO: Setup methods for this type to covert entries to IP Address strings
+// or whatever format we end up needing. We could even have multiple methods.
+type ipAddressOctetsIndex map[int][]int
+
+func isCIDR(s string) bool {
+	_, _, err := net.ParseCIDR(s)
+
+	return err == nil
+}
+
+func octetWithinBounds(i int) bool {
+	return i >= 0 && i <= 255
+}
+
+func main() {
+
+	if len(os.Args) < 2 {
+		fmt.Println("Error: Missing test range")
+		os.Exit(1)
+	}
+
+	givenIPsList := make([]string, 0, 1024)
+	// var givenIPsList []string
+
+	input := os.Args[1]
+
+	// Without using a pointer to this slice the slice header is passed
+	// instead. This header points to a backing array of a fixed size. Once
+	// the slice exceeds that initial backing array the slice header is
+	// pointed to a new array with sufficient capacity. Thus, if working with
+	// a slice header, this function would end up trying to access the old
+	// array through the copy of the slice header it receives. This would
+	// either result in a subset of the intended values or if deferred early
+	// (as we're doing), would result in an empty slice.
+	defer func(ipAddrs *[]string) {
+
+		switch {
+		case ipAddrs == nil:
+			fmt.Println("specified IPs slice is nil")
+
+		case len(*ipAddrs) > 512:
+			fmt.Printf("Final IPs list has %d IPs (skipping printing of large list)\n", len(*ipAddrs))
+
+		default:
+			fmt.Printf("Final IPs list (%d IPs): %v\n", len(*ipAddrs), *ipAddrs)
+
+		}
+
+	}(&givenIPsList)
+
+	// non-empty, comma-separated list of values
+	// loop over each value
+	// confirm that . character is present
+	// switch
+	// if slash character is found
+	// attempt to parse whole value as CIDR range
+	// if dash character is found
+	// split on . character
+	// confirm that 4 octets are found
+	// check each octet to ensure that each is within upper/lower bounds
+	//
+
+	switch {
+
+	// assume that user specified a CIDR mask
+	case strings.Contains(input, "/"):
+
+		if isCIDR(input) {
+			ipAddrs, count, err := netutils.CIDRHosts(input)
+			if err != nil {
+				fmt.Printf("error parsing CIDR range: %s\n", err)
+			}
+			fmt.Printf("%q is a CIDR rangeof %d IPs\n", input, count)
+			givenIPsList = append(givenIPsList, ipAddrs...)
+		}
+
+	// valid (presumably single) IPv4 or IPv6 address
+	case net.ParseIP(input) != nil:
+
+		fmt.Printf("%q is an IP Address\n", input)
+		givenIPsList = append(givenIPsList, input)
+
+	// no CIDR mask, and not a single IP Address (earlier check would have
+	// triggered), so potentially a partial range of IPv4 Addresses
+	case strings.Contains(input, "."):
+
+		octets := strings.Split(input, ".")
+
+		if len(octets) != 4 {
+			fmt.Printf(
+				"%q (%d octets) not IPv4 Address; does not contain 4 octets\n",
+				input,
+				len(octets),
+			)
+
+			return
+		}
+
+		fmt.Printf("%q is a potential IP Address range\n", input)
+
+		// reminder: at this point single IP Address was handled by earlier
+		// switch case. We are either dealing with a partial range or invalid
+		// value.
+
+		// check for dash character used to specify partial IP range
+		if !strings.Contains(input, "-") {
+			fmt.Printf(
+				"%q not IP Address range; does not contain dash character\n",
+				input,
+			)
+
+			return
+		}
+
+		ipAddrOctIdx := make(ipAddressOctetsIndex)
+
+		for octIdx := range octets {
+
+			// split on dashes, loop over that
+			halves := strings.Split(octets[octIdx], "-")
+
+			switch {
+
+			// dash is not present
+			case len(halves) == 1:
+
+				// fmt.Printf("DEBUG: octet %d does not have a dash\n", octIdx)
+
+				num, err := strconv.Atoi(halves[0])
+				if err != nil {
+					fmt.Printf(
+						"octet %q of IP pattern %q invalid; "+
+							"non-numeric values present\n",
+						octets[octIdx],
+						input,
+					)
+
+					return
+				}
+
+				if !octetWithinBounds(num) {
+					fmt.Printf(
+						"octet %q of IP pattern %q outside lower (0), upper (255) bounds\n",
+						octets[octIdx],
+						input,
+					)
+
+					return
+				}
+
+				// extend values for this octet
+				ipAddrOctIdx[octIdx] = append(ipAddrOctIdx[octIdx], num)
+
+				// fmt.Printf("DEBUG: %+v\n", ipAddrOctIdx)
+
+			// one dash present, this is a range separator
+			case len(halves) == 2:
+
+				rangeStart, err := strconv.Atoi(halves[0])
+				if err != nil {
+					fmt.Printf(
+						"octet %q of IP pattern %q invalid; "+
+							"non-numeric values present\n",
+						octets[octIdx],
+						input,
+					)
+
+					return
+				}
+
+				rangeEnd, err := strconv.Atoi(halves[1])
+				if err != nil {
+					fmt.Printf(
+						"octet %q of IP pattern %q invalid; "+
+							"non-numeric values present\n",
+						octets[octIdx],
+						input,
+					)
+
+					return
+				}
+
+				// TODO: range over halves and begin building valid values
+				// using existing octet values
+				//
+				// e.g., 192.168.1-15.10-12 and assume we are on octet 3 at
+				// this point we should combine "192.168." with "10", "11",
+				// "12", "13", "14", "15" this process should be repeated once
+				// octet 4 is examined
+
+				// should I use an array to track this?
+				// struct with 4 fields to track the 4 octets?
+
+				switch {
+				case rangeStart > rangeEnd:
+					fmt.Printf(
+						"%q is invalid octet range; "+
+							"given start value %d greater than end value %d\n",
+						octets[octIdx],
+						rangeStart,
+						rangeEnd,
+					)
+
+					return
+
+				case rangeStart == rangeEnd:
+					fmt.Printf(
+						"%q is invalid octet range; "+
+							"given start value %d equal to end value %d\n",
+						octets[octIdx],
+						rangeStart,
+						rangeEnd,
+					)
+
+					return
+				}
+
+				for i := rangeStart; i <= rangeEnd; i++ {
+					if !octetWithinBounds(i) {
+						fmt.Printf(
+							"octet %q of IP pattern %q outside lower (0), upper (255) bounds\n",
+							octets[octIdx],
+							input,
+						)
+
+						return
+					}
+
+					// extend values for this octet
+					ipAddrOctIdx[octIdx] = append(ipAddrOctIdx[octIdx], i)
+					// fmt.Printf("DEBUG: %+v\n", ipAddrOctIdx)
+				}
+
+			// more than one dash present in octet, malformed range
+			default:
+
+				numDashes := strings.Count(octets[octIdx], "-")
+				fmt.Printf(
+					"%d dash separators in octet %q (%d of %d); expected one\n",
+					numDashes,
+					octIdx,
+					octIdx+1,
+					len(octets),
+				)
+
+				return
+
+			}
+
+		}
+
+		// EXPAND THE INDEX OF VALUES TO IP ADDRESSES HERE
+
+		// loop over map (or not?)
+		// the map should be length 4
+		// each key should be numbered 0-3
+		// each key points to a slice of values for the octet that the key represents
+
+		if len(ipAddrOctIdx) != len(octets) {
+			fmt.Printf(
+				"ipAddress octet map size incorrect; got %d, wanted %d\n",
+				len(ipAddrOctIdx),
+				len(octets),
+			)
+
+			return
+		}
+
+		// Ex IP: 192.168.5.10
+		// 192(w).168(x).5(y).10(z)
+		// var mapEntriesSize int
+		// for i := range ipAddrOctIdx {
+		// 	mapEntriesSize += ipAddrOctIdx[i]
+		// }
+
+		for i := range ipAddrOctIdx[0] {
+			w := strconv.Itoa(ipAddrOctIdx[0][i])
+
+			for j := range ipAddrOctIdx[1] {
+				x := strconv.Itoa(ipAddrOctIdx[1][j])
+
+				for k := range ipAddrOctIdx[2] {
+					y := strconv.Itoa(ipAddrOctIdx[2][k])
+
+					for l := range ipAddrOctIdx[3] {
+						z := strconv.Itoa(ipAddrOctIdx[3][l])
+
+						// fmt.Println(strings.Join([]string{w, x, y, z}, "."))
+						ipAddrString := strings.Join([]string{w, x, y, z}, ".")
+
+						if net.ParseIP(ipAddrString) == nil {
+							fmt.Printf(
+								"%q (from parsed range) is an invalid IP Address\n",
+								ipAddrString,
+							)
+
+							return
+						}
+
+						givenIPsList = append(givenIPsList, ipAddrString)
+					}
+				}
+			}
+		}
+
+	default:
+		fmt.Printf("%q not recognized as IP Address or IP Address range\n", input)
+
+		return
+	}
+
+	// https://golang.org/pkg/net/#IPNet.Contains
+
+}

--- a/doc.go
+++ b/doc.go
@@ -18,7 +18,7 @@ FEATURES
 
 • CLI tool for verifying certificates of certificate-enabled services or files
 
-• CLI tool for generating summary of discovered certificates from given IP ranges and ports
+• CLI tool for generating summary of discovered certificates from given IP Addresses (single and ranges) and ports
 
 USAGE
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -24,7 +24,7 @@ const (
 	dnsNameFlagHelp                  string = "The fully-qualified domain name of the remote system to be used for hostname verification. This option can be used for cases where make the initial connection using a name or IP not associated with the certificate."
 	logLevelFlagHelp                 string = "Sets log level to one of disabled, panic, fatal, error, warn, info, debug or trace."
 	serverFlagHelp                   string = "The fully-qualified domain name or IP Address of the remote system whose cert(s) will be monitored. The value provided will be validated against the Common Name and Subject Alternate Names fields."
-	cidrRangeFlagHelp                string = "List of comma-separated CIDR IP ranges to scan for certificates."
+	ipAddressesFlagHelp              string = "List of comma-separated individual IP Addresses, CIDR IP ranges or partial (dash-separated) ranges (e.g., 192.168.2.10-15) to scan for certificates."
 	portFlagHelp                     string = "TCP port of the remote certificate-enabled service. This is usually 443 (HTTPS) or 636 (LDAPS)."
 	portsListFlagHelp                string = "List of comma-separated TCP ports to check for certificates. If not specified, the list defaults to 443 only."
 	timeoutFlagHelp                  string = "Timeout value in seconds allowed before a connection attempt to a remote certificate-enabled service (in order to retrieve the certificate) is abandoned and an error returned."
@@ -96,3 +96,7 @@ const (
 	appTypeInspecter string = "inspecter"
 	appTypeScanner   string = "scanner"
 )
+
+// limit number of IP Address "printed" by the Stringer interface to a
+// human-readable number
+const mvipPrintLimit int = 50

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -47,8 +47,8 @@ func (c *Config) handleFlagsConfig(appType AppType) {
 		flag.IntVar(&c.timeoutPortScan, "scan-timeout", defaultPortScanTimeout, timeoutPortScanFlagHelp)
 		flag.IntVar(&c.timeoutPortScan, "st", defaultPortScanTimeout, timeoutPortScanFlagHelp+" (shorthand)")
 
-		flag.Var(&c.CIDRRange, "cidr-ip-range", cidrRangeFlagHelp)
-		flag.Var(&c.CIDRRange, "cir", cidrRangeFlagHelp+" (shorthand)")
+		flag.Var(&c.ipAddresses, "ip-addresses", ipAddressesFlagHelp)
+		flag.Var(&c.ipAddresses, "ips", ipAddressesFlagHelp+" (shorthand)")
 
 		flag.IntVar(&c.PortScanRateLimit, "scan-rate-limit", defaultPortScanRateLimit, portScanRateLimitFlagHelp)
 		flag.IntVar(&c.PortScanRateLimit, "srl", defaultPortScanRateLimit, portScanRateLimitFlagHelp+" (shorthand)")

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -32,3 +32,13 @@ func (c Config) CertPorts() []int {
 
 	return []int{defaultPortsListEntry}
 }
+
+// IPAddresses returns a list of individual IP Addresses expanded from any
+// user-specified IP Address ranges.
+func (c Config) IPAddresses() []string {
+	if c.ipAddresses.expanded != nil {
+		return c.ipAddresses.expanded
+	}
+
+	return []string{}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -67,14 +67,8 @@ func (c Config) validate(appType AppType) error {
 			)
 		}
 
-		// NOTE: It is likely that we'll use a different flag later in order
-		// to accept a mix of single, CIDR range, and a standard
-		// start-finish range of IP Addresses.
-		// if c.CIDRRange == "" {
-		// 	return fmt.Errorf("CIDR IP range not provided")
-		// }
-		if c.CIDRRange == nil {
-			return fmt.Errorf("CIDR IP range(s) not provided")
+		if c.IPAddresses() == nil {
+			return fmt.Errorf("IP Addresses (one or many, single or ranges) not provided")
 		}
 
 		// TODO: Figure out how to (or if we need to) validate mix of boolean

--- a/internal/netutils/types.go
+++ b/internal/netutils/types.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package netutils
+
+import "net"
+
+// PortCheckResult indicates whether a TCP port is open and what error (if
+// any) occurred checking the port.
+type PortCheckResult struct {
+	IPAddress net.IPAddr
+	Port      int
+	Open      bool
+	Err       error
+}
+
+// PortCheckResults is a collection of PortCheckResult intended for bulk
+// operations such as filtering or generating summaries.
+type PortCheckResults []PortCheckResult
+
+// PortCheckResultsIndex maps the results slice from scan attempts against a
+// specified list of ports to an IP Address associated with scanned ports.
+type PortCheckResultsIndex map[string]PortCheckResults
+
+// IPv4AddressOctetsIndex is a map of IPv4 octets to values within those
+// octets associated with partial ranges. This type is used to help implement
+// support for octet range addressing.
+type IPv4AddressOctetsIndex map[int][]int


### PR DESCRIPTION
## Changes

- partial support of "octet range addressing" functionality
  as popularized by nmap (not sure if it is the origin)
  - dash separator logic supported
  - comma separated octet values support (to omit some hosts
    from specified specified octet range) *not* implemented
    - perhaps in the future

- support for single IP Addresses

- CIDR range support retained

In short, all three formats are how supported. Any value not
matching one of these patterns is rejected. This includes
hostnames and/or FQDNs, which as of this writing are not *yet*
supported.

## References

- refs GH-136
- refs https://nmap.org/book/man-target-specification.html