### PR TITLE
certsum: Refactor into separate helper funcs

### DIFF
--- a/cmd/certsum/certcheck.go
+++ b/cmd/certsum/certcheck.go
@@ -1,0 +1,141 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/atc0005/check-certs/internal/certs"
+	"github.com/atc0005/check-certs/internal/netutils"
+	"github.com/rs/zerolog"
+)
+
+// certScanCollector is called as a goroutine prior to launching the cert
+// scanner function, also as a goroutine. This goroutine continues to run
+// until all results are collected.
+func certScanCollector(
+	discoveredCertChains *certs.DiscoveredCertChains,
+	results <-chan certs.DiscoveredCertChain,
+	wg *sync.WaitGroup) {
+
+	// help ensure that we don't forget to signal that we're done
+	defer wg.Done()
+
+	for result := range results {
+		*discoveredCertChains = append(*discoveredCertChains, result)
+	}
+}
+
+// certScanner is called as a goroutine after launching the cert scan
+// collector goroutine. This function performs a certificate chain check
+// against all specified ports that were previously found to be open and
+// returns the results of those checks on a channel that the collector
+// goroutine monitors. This goroutine continues to run until all open ports
+// are checked, either successfully or once a specified timeout is reached.
+func certScanner(
+	resultsIndex netutils.PortCheckResultsIndex,
+	showHostsWithClosedPorts bool,
+	showPortScanResults bool,
+	timeout time.Duration,
+	results chan<- certs.DiscoveredCertChain,
+	rateLimiter chan struct{}, // needs to allow send & receive
+	log zerolog.Logger,
+	wg *sync.WaitGroup,
+) {
+
+	// caller sets this just before calling this function
+	defer wg.Done()
+
+	for host, checkResults := range resultsIndex {
+
+		// unless user opted to show hosts with *all* closed ports, skip the
+		// host and continue to the next one
+		if !showHostsWithClosedPorts && !checkResults.HasOpenPort() {
+			continue
+		}
+
+		switch {
+		case showPortScanResults:
+			portSummary := func() string {
+				if checkResults.HasOpenPort() {
+					return checkResults.Summary()
+				}
+				return "None"
+			}()
+
+			// 192.168.1.2: [443: true, 636: false]
+			fmt.Printf("%s: [%s]\n", host, portSummary)
+		default:
+			fmt.Printf(".")
+		}
+
+		for _, result := range checkResults {
+			if result.Open {
+
+				wg.Add(1)
+				rateLimiter <- struct{}{}
+
+				go func(
+					ipAddr string,
+					port int,
+					timeout time.Duration,
+					results chan<- certs.DiscoveredCertChain,
+					log zerolog.Logger,
+				) {
+
+					// make sure we give up our spot when finished
+					defer func() {
+						// indicate that we're done with this goroutine
+						wg.Done()
+
+						// release spot for next (held back) goroutine to run
+						<-rateLimiter
+					}()
+
+					var certFetchErr error
+					certChain, certFetchErr := netutils.GetCerts(
+						ipAddr,
+						port,
+						timeout,
+						log,
+					)
+					if certFetchErr != nil {
+						if !showPortScanResults {
+							// will need to insert a newline in-between error
+							// output if we're not showing port summary results
+							fmt.Println()
+						}
+						log.Error().
+							Err(certFetchErr).
+							Str("host", result.IPAddress.String()).
+							Int("port", result.Port).
+							Msg("error fetching certificates chain")
+
+						// os.Exit(1)
+						// TODO: Decide whether fetch errors are critical or just warning level
+						wg.Done()
+						return
+					}
+
+					results <- certs.DiscoveredCertChain{
+						Host:  result.IPAddress.String(),
+						Port:  result.Port,
+						Certs: certChain,
+					}
+
+				}(result.IPAddress.String(), result.Port, timeout, results, log)
+
+			}
+
+		}
+
+	}
+
+}

--- a/cmd/certsum/portscan.go
+++ b/cmd/certsum/portscan.go
@@ -1,0 +1,131 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"sync"
+	"time"
+
+	"github.com/atc0005/check-certs/internal/netutils"
+	"github.com/rs/zerolog"
+)
+
+// certScanCollector is called as a goroutine prior to launching the port
+// scanner function, also as a goroutine. This goroutine continues to
+// run until all results are collected.
+func portScanCollector(
+	resultsIdx netutils.PortCheckResultsIndex,
+	results <-chan netutils.PortCheckResult,
+	log zerolog.Logger,
+	wg *sync.WaitGroup,
+) {
+
+	log.Debug().Msg("starting collector routine")
+
+	// help ensure that we don't forget to signal that we're done
+	defer wg.Done()
+
+	// Receive check results, update index
+	for checkResult := range results {
+
+		log.Debug().Msgf(
+			"Adding results for %v to index",
+			checkResult.IPAddress.String(),
+		)
+
+		// grow the index of IP Address to port scan results for later review
+		resultsIdx[checkResult.IPAddress.String()] = append(
+			resultsIdx[checkResult.IPAddress.String()],
+			checkResult,
+		)
+	}
+
+	log.Debug().Msg("exiting collector routine")
+
+}
+
+// portScanner is called as a goroutine after launching the port scan
+// collector goroutine. This function performs a port scan against all
+// user-specified ports and returns the results of those scan attempts on a
+// channel that the collector goroutine monitors. This goroutine continues to
+// run until all ports are checked, either successfully or once a specified
+// timeout is reached.
+func portScanner(
+	ips []string,
+	ports []int,
+	timeout time.Duration,
+	results chan<- netutils.PortCheckResult,
+	rateLimiter chan struct{}, // needs to allow send & receive
+	log zerolog.Logger,
+	wg *sync.WaitGroup,
+) {
+
+	log.Debug().Msg("Launching port scanner goroutine")
+
+	// caller sets this just before calling this function
+	defer wg.Done()
+
+	for _, ip := range ips {
+
+		log.Debug().Msgf("Checking IP: %v", ip)
+
+		for _, port := range ports {
+
+			log.Debug().Msgf("Checking port %v for IP: %v", port, ip)
+
+			// indicate that we are launching a goroutine that will be tracked
+			// and reserve a spot in the (limited) channel
+			wg.Add(1)
+			rateLimiter <- struct{}{}
+
+			go func(
+				ipAddr string,
+				port int,
+				scanTimeout time.Duration,
+				results chan<- netutils.PortCheckResult,
+				rateLimiter chan struct{},
+				log zerolog.Logger,
+			) {
+
+				// make sure we give up our spot when finished
+				defer func() {
+					// indicate that we're done with this goroutine
+					wg.Done()
+
+					// release spot for next (held back) goroutine to run
+					<-rateLimiter
+				}()
+
+				portState := netutils.CheckPort(ipAddr, port, scanTimeout)
+				if portState.Err != nil {
+					// TODO: Check specific error type to determine how to
+					// proceed. For now, we'll just emit the error and
+					// continue.
+					log.Error().
+						Str("host", ipAddr).
+						Int("port", port).
+						Err(portState.Err)
+				}
+
+				log.Debug().Msg("Sending result back on channel")
+
+				results <- portState
+
+				log.Debug().Msg("Sent result on channel, proceeding")
+
+				// if portState.Open {
+				// 	fmt.Printf("%v: port %v open\n", ipAddr, port)
+				// }
+
+			}(ip, port, timeout, results, rateLimiter, log)
+		}
+	}
+
+	log.Debug().Msg("Finished wrapper port scanner goroutine")
+
+}


### PR DESCRIPTION
Break out core functionality into separate functions
dedicated to execution as goroutines:

- collectors (port scan results, cert check results)
- scanners (port scanner, cert scanner)

Still more work to do. This is mostly an attempt to break out
the code for easier review.

refs GH-135