### PR TITLE
Add missing Msg() call for error logging attempt, set to debug log level instead

### DIFF
--- a/cmd/certsum/portscan.go
+++ b/cmd/certsum/portscan.go
@@ -104,12 +104,14 @@ func portScanner(
 				portState := netutils.CheckPort(ipAddr, port, scanTimeout)
 				if portState.Err != nil {
 					// TODO: Check specific error type to determine how to
-					// proceed. For now, we'll just emit the error and
+					// proceed. For now, we'll just assume that we're dealing
+					// with a timeout, emit the error as a debug message and
 					// continue.
-					log.Error().
+					log.Debug().
 						Str("host", ipAddr).
 						Int("port", port).
-						Err(portState.Err)
+						Err(portState.Err).
+						Msg("")
 				}
 
 				log.Debug().Msg("Sending result back on channel")


### PR DESCRIPTION
Add missing Msg() invocation for logger call associated with a port scan error. Without this, the logger call fails to emit the intended error message. Because the most common error case for a port scan is an i/o timeout, we emit the error message at debug level and continue scanning the next port.