### PR TITLE
Remove extra wg.Done() call from certScanner

### DIFF
--- a/cmd/certsum/certcheck.go
+++ b/cmd/certsum/certcheck.go
@@ -120,7 +120,7 @@ func certScanner(
 
 						// os.Exit(1)
 						// TODO: Decide whether fetch errors are critical or just warning level
-						wg.Done()
+
 						return
 					}
 


### PR DESCRIPTION
The previously deferred call handles this already.

This results in a `panic: sync: negative WaitGroup counter` error when a failure fetching a certificate chain occurs.