### PR TITLE
Increase summary output details

### DIFF
--- a/cmd/certsum/summary.go
+++ b/cmd/certsum/summary.go
@@ -11,6 +11,31 @@ import (
 	"github.com/atc0005/check-certs/internal/certs"
 )
 
+func printLeadIn(
+	showAll bool,
+	discoveredChains certs.DiscoveredCertChains,
+	ageCritical time.Time,
+	ageWarning time.Time,
+) {
+
+	certIssuesCount := discoveredChains.NumProblems(ageCritical, ageWarning)
+
+	fmt.Printf("%d certificates (%d issues) found.\n", len(discoveredChains), certIssuesCount)
+
+	if certIssuesCount == 0 {
+		fmt.Printf("\nResults: No certificate issues found!\n")
+		return
+	}
+
+	resultsDescription := "all"
+	if !showAll {
+		resultsDescription = "issues only"
+	}
+
+	fmt.Printf("\nResults (%s):\n\n", resultsDescription)
+
+}
+
 func printSummaryHighLevel(
 	showAllHosts bool,
 	discoveredChains certs.DiscoveredCertChains,
@@ -22,12 +47,7 @@ func printSummaryHighLevel(
 	certsExpireAgeWarning := now.AddDate(0, 0, ageWarning)
 	certsExpireAgeCritical := now.AddDate(0, 0, ageCritical)
 
-	if !discoveredChains.HasProblems(certsExpireAgeCritical, certsExpireAgeWarning) {
-		fmt.Printf("\nResults: No certificate issues found!\n")
-		return
-	}
-
-	fmt.Printf("\nResults:\n\n")
+	printLeadIn(showAllHosts, discoveredChains, certsExpireAgeCritical, certsExpireAgeWarning)
 
 	tw := tabwriter.NewWriter(os.Stdout, 8, 8, 4, '\t', 0)
 
@@ -104,12 +124,7 @@ func printSummaryDetailedLevel(
 	certsExpireAgeWarning := now.AddDate(0, 0, ageWarning)
 	certsExpireAgeCritical := now.AddDate(0, 0, ageCritical)
 
-	if !discoveredChains.HasProblems(certsExpireAgeCritical, certsExpireAgeWarning) {
-		fmt.Printf("\nResults: No certificate issues found!\n")
-		return
-	}
-
-	fmt.Printf("\nResults:\n\n")
+	printLeadIn(showAllCerts, discoveredChains, certsExpireAgeCritical, certsExpireAgeWarning)
 
 	tw := tabwriter.NewWriter(os.Stdout, 8, 8, 4, '\t', 0)
 

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -749,6 +749,32 @@ func (dcc DiscoveredCertChains) HasProblems(
 
 }
 
+// NumProblems indicates how many evaluated certificates are expired or
+// expiring soon.
+func (dcc DiscoveredCertChains) NumProblems(
+	certsExpireAgeCritical time.Time,
+	certsExpireAgeWarning time.Time) int {
+
+	var problems int
+	for _, chain := range dcc {
+
+		hasExpiredCerts := HasExpiredCert(chain.Certs)
+		hasExpiringCerts := HasExpiringCert(
+			chain.Certs,
+			certsExpireAgeCritical,
+			certsExpireAgeWarning,
+		)
+
+		if hasExpiredCerts || hasExpiringCerts {
+			problems++
+		}
+
+	}
+
+	return problems
+
+}
+
 // ChainSummary receives a certificate chain, the critical age threshold and
 // the warning age threshold and generates a summary of certificate details.
 func ChainSummary(


### PR DESCRIPTION
- note how many of the discovered certs have issues
- note the type of results display: `all` or `issues only`

The goal is to help tell at a glance what type of output that we're looking at. Less useful when immediately reviewing output after running the command perhaps, but hopefully useful if someone captures the output and records it on a ticket somewhere for later review.