### PR TITLE
Collapse summary output helper func

### DIFF
--- a/cmd/certsum/summary.go
+++ b/cmd/certsum/summary.go
@@ -11,31 +11,6 @@ import (
 	"github.com/atc0005/check-certs/internal/certs"
 )
 
-func printLeadIn(
-	showAll bool,
-	discoveredChains certs.DiscoveredCertChains,
-	ageCritical time.Time,
-	ageWarning time.Time,
-) {
-
-	certIssuesCount := discoveredChains.NumProblems(ageCritical, ageWarning)
-
-	fmt.Printf("%d certificates (%d issues) found.\n", len(discoveredChains), certIssuesCount)
-
-	if certIssuesCount == 0 {
-		fmt.Printf("\nResults: No certificate issues found!\n")
-		return
-	}
-
-	resultsDescription := "all"
-	if !showAll {
-		resultsDescription = "issues only"
-	}
-
-	fmt.Printf("\nResults (%s):\n\n", resultsDescription)
-
-}
-
 func printSummaryHighLevel(
 	showAllHosts bool,
 	discoveredChains certs.DiscoveredCertChains,
@@ -47,7 +22,21 @@ func printSummaryHighLevel(
 	certsExpireAgeWarning := now.AddDate(0, 0, ageWarning)
 	certsExpireAgeCritical := now.AddDate(0, 0, ageCritical)
 
-	printLeadIn(showAllHosts, discoveredChains, certsExpireAgeCritical, certsExpireAgeWarning)
+	certIssuesCount := discoveredChains.NumProblems(certsExpireAgeCritical, certsExpireAgeWarning)
+
+	fmt.Printf("%d certificates (%d issues) found.\n", len(discoveredChains), certIssuesCount)
+
+	if certIssuesCount == 0 {
+		fmt.Printf("\nResults: No certificate issues found!\n")
+		return
+	}
+
+	resultsDescription := "all"
+	if !showAllHosts {
+		resultsDescription = "issues only"
+	}
+
+	fmt.Printf("\nResults (%s):\n\n", resultsDescription)
 
 	tw := tabwriter.NewWriter(os.Stdout, 8, 8, 4, '\t', 0)
 
@@ -124,7 +113,21 @@ func printSummaryDetailedLevel(
 	certsExpireAgeWarning := now.AddDate(0, 0, ageWarning)
 	certsExpireAgeCritical := now.AddDate(0, 0, ageCritical)
 
-	printLeadIn(showAllCerts, discoveredChains, certsExpireAgeCritical, certsExpireAgeWarning)
+	certIssuesCount := discoveredChains.NumProblems(certsExpireAgeCritical, certsExpireAgeWarning)
+
+	fmt.Printf("%d certificates (%d issues) found.\n", len(discoveredChains), certIssuesCount)
+
+	if certIssuesCount == 0 {
+		fmt.Printf("\nResults: No certificate issues found!\n")
+		return
+	}
+
+	resultsDescription := "all"
+	if !showAllCerts {
+		resultsDescription = "issues only"
+	}
+
+	fmt.Printf("\nResults (%s):\n\n", resultsDescription)
 
 	tw := tabwriter.NewWriter(os.Stdout, 8, 8, 4, '\t', 0)
 


### PR DESCRIPTION
While the idea is useful, it doesn't correctly handle early exit when there are no cert issues to report. Collapsing that helper function back into (admittedly redundant) existing summary functions.