### PR TITLE
Refactor concurrency implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@
 *.out
 
 # Ignore Visual Studio Code workspace-level settings
-.vscode/settings.json
+/.vscode
 
 # Ignore local "scratch" directory of temporary files
 scratch/

--- a/README.md
+++ b/README.md
@@ -116,13 +116,17 @@ at a future date, unless others find it useful.
 
 `certsum` is an IP range cert scanner prototype. This tool is currently of
 "alpha" level quality; many of the exposed flags, help text and summary output
-is subject to change significantly in later releases.
+are subject to change significantly in later releases.
 
 This tool is intended for scanning one or more given IP ranges in order to
 generate a report for discovered certificates.
 
-Performance is acceptable for smaller IP ranges, but this tool will require
-further refactoring to be useful for scanning larger IP ranges.
+Performance is likely to be acceptable as-is for smaller IP ranges, but may be
+adjusted as needed using the rate limit tuning flag (see the [configuration
+options](#configuration-options) section for details). The current default
+value is an attempt to balance scanning speed against OS limitations on the
+number of open file handles. If adjusting this value, start with small
+increments to determine best results for your environment.
 
 IP Addresses may be specified as comma-separated values:
 
@@ -162,7 +166,7 @@ of detail in the provided output.
     - critical threshold
 
 - Validate provided hostname against Common Name *or* one of the available
-  SANs entries (see [configuration options](#configuration-options) )
+  SANs entries (see [configuration options](#configuration-options))
 
 - Optional support for verifying SANs entries on a certificate against a
   provided list
@@ -368,7 +372,7 @@ change, perhaps even significantly, in future releases.
 | `t`, `timeout`                         | No       | `10`    | No     | *positive whole number of seconds*                                                      | Timeout value in seconds allowed before a connection attempt to a remote certificate-enabled service (in order to retrieve the certificate) is abandoned and an error returned.                                                                                                                                                                                       |
 | `se`, `sans-entries`                   | No       |         | No     | *comma-separated list of values*                                                        | One or many Subject Alternate Names (SANs) expected for the certificate used by the remote service. If provided, this list of comma-separated (optional) values is required for the certificate to pass validation. If the case-insensitive SKIPSANSCHECKS keyword is provided this validation will be skipped, effectively turning the use of this flag into a NOOP. |
 | `st`, `scan-timeout`                   | No       | 200     | No     | *positive whole number of milliseconds*                                                 | The number of milliseconds before a connection attempt during a port scan is abandoned and an error returned. This timeout value is separate from the general `timeout` value used when retrieving certificates. This setting is used specifically to quickly determine port state as part of bulk operations where speed is crucial.                                 |
-| `srl`, `scan-rate-limit`               | No       | 100     | No     | *positive whole number*                                                                 | Maximum concurrent port scans. Remaining port scans are queued until an existing scan completes.                                                                                                                                                                                                                                                                      |
+| `srl`, `scan-rate-limit`               | No       | 100     | No     | *positive whole number*                                                                 | Maximum concurrent port and certificate scans. Remaining scans are queued until an existing scan completes.                                                                                                                                                                                                                                                           |
 | `ips`, `hosts`                         | No       |         | No     | *one or more valid, comma-separated IP Addresses (single or range), hostnames or FQDNs* | List of comma-separated individual IP Addresses, CIDR IP ranges, partial (dash-separated) ranges (e.g., 192.168.2.10-15), hostnames or FQDNs to scan for certificates.                                                                                                                                                                                                |
 | `p`, `ports`                           | No       | 443     | No     | *one or more valid, comma-separated TCP ports*                                          | List of comma-separated TCP ports to check for certificates. If not specified, the list defaults to 443 only.                                                                                                                                                                                                                                                         |
 | `spsr`, `show-port-scan-results`       | No       | `false` | No     | `true`, `false`                                                                         | Toggles listing host port scan results.                                                                                                                                                                                                                                                                                                                               |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,8 +212,8 @@ type Config struct {
 	// FQDNs to scan for certs.
 	hosts multiValueHostsFlag
 
-	// ScanLimit is the maximum number of concurrent port scan attempts.
-	PortScanRateLimit int
+	// ScanRateLimit is the maximum number of concurrent port scan attempts.
+	ScanRateLimit int
 
 	// DNSName is the fully-qualified domain name associated with the
 	// certificate. This is usually specified when the FQDN or IP used to make

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -27,9 +27,9 @@ const (
 	hostsFlagHelp                    string = "List of comma-separated individual IP Addresses, CIDR IP ranges, partial (dash-separated) ranges (e.g., 192.168.2.10-15), hostnames or FQDNs to scan for certificates."
 	portFlagHelp                     string = "TCP port of the remote certificate-enabled service. This is usually 443 (HTTPS) or 636 (LDAPS)."
 	portsListFlagHelp                string = "List of comma-separated TCP ports to check for certificates. If not specified, the list defaults to 443 only."
-	timeoutFlagHelp                  string = "Timeout value in seconds allowed before a connection attempt to a remote certificate-enabled service (in order to retrieve the certificate) is abandoned and an error returned."
+	timeoutConnectFlagHelp           string = "Timeout value in seconds allowed before a connection attempt to a remote certificate-enabled service (in order to retrieve the certificate) is abandoned and an error returned."
 	timeoutPortScanFlagHelp          string = "The number of milliseconds before a connection attempt during a port scan is abandoned and an error returned. This timeout value is separate from the general `timeout` value used when retrieving certificates. This setting is used specifically to quickly determine port state as part of bulk operations where speed is crucial."
-	portScanRateLimitFlagHelp        string = "Maximum concurrent port scans. Remaining port scans are queued until an existing scan completes."
+	scanRateLimitFlagHelp            string = "Maximum concurrent port and certificate scans. Remaining scans are queued until an existing scan completes."
 	emitCertTextFlagHelp             string = "Toggles emission of x509 TLS certificates in an OpenSSL-inspired text format. This output is disabled by default."
 	filenameFlagHelp                 string = "Fully-qualified path to a file containing one or more certificates."
 	certExpireAgeWarningFlagHelp     string = "The number of days remaining before certificate expiration when this application will will flag the NotAfter certificate field as a WARNING state."
@@ -48,7 +48,6 @@ const (
 	defaultServer                string = ""
 	defaultDNSName               string = ""
 	defaultPort                  int    = 443
-	defaultTimeout               int    = 10
 	defaultEmitCertText          bool   = false
 	defaultFilename              string = ""
 	defaultBranding              bool   = false
@@ -60,11 +59,20 @@ const (
 	// Default CRITICAL threshold is 15 days
 	defaultCertExpireAgeCritical int = 15
 
+	// Default timeout (in seconds) used when retreiving a certificate from a
+	// specified TCP port previously discovered to be open.
+	defaultConnectTimeout int = 10
+
 	// Default timeout (in milliseconds) used when testing whether a TCP port
 	// is open or closed.
 	defaultPortScanTimeout = 200
 
-	defaultPortScanRateLimit int = 100
+	// this limit is used by port scanner per-host and per-port goroutines
+	// along with certificate scanner goroutines. In an effort to prevent
+	// deadlocks, per-host goroutines limits are independent of per-port
+	// goroutines with each type of goroutine having their own "queue" that
+	// they work from.
+	defaultScanRateLimit int = 100
 
 	// For the "scanner", this flag value is required.
 	// defaultCIDRRange string = ""

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -50,8 +50,8 @@ func (c *Config) handleFlagsConfig(appType AppType) {
 		flag.Var(&c.hosts, "hosts", hostsFlagHelp)
 		flag.Var(&c.hosts, "ips", hostsFlagHelp+" (alt name)")
 
-		flag.IntVar(&c.PortScanRateLimit, "scan-rate-limit", defaultPortScanRateLimit, portScanRateLimitFlagHelp)
-		flag.IntVar(&c.PortScanRateLimit, "srl", defaultPortScanRateLimit, portScanRateLimitFlagHelp+" (shorthand)")
+		flag.IntVar(&c.ScanRateLimit, "scan-rate-limit", defaultScanRateLimit, scanRateLimitFlagHelp)
+		flag.IntVar(&c.ScanRateLimit, "srl", defaultScanRateLimit, scanRateLimitFlagHelp+" (shorthand)")
 
 		flag.Var(&c.portsList, "ports", portsListFlagHelp)
 		flag.Var(&c.portsList, "p", portsListFlagHelp+" (shorthand)")
@@ -84,8 +84,8 @@ func (c *Config) handleFlagsConfig(appType AppType) {
 	flag.IntVar(&c.AgeCritical, "c", defaultCertExpireAgeCritical, certExpireAgeCriticalFlagHelp)
 	flag.IntVar(&c.AgeCritical, "age-critical", defaultCertExpireAgeCritical, certExpireAgeCriticalFlagHelp)
 
-	flag.IntVar(&c.timeout, "t", defaultTimeout, timeoutFlagHelp)
-	flag.IntVar(&c.timeout, "timeout", defaultTimeout, timeoutFlagHelp)
+	flag.IntVar(&c.timeout, "t", defaultConnectTimeout, timeoutConnectFlagHelp)
+	flag.IntVar(&c.timeout, "timeout", defaultConnectTimeout, timeoutConnectFlagHelp)
 
 	flag.StringVar(&c.LoggingLevel, "ll", defaultLogLevel, logLevelFlagHelp)
 	flag.StringVar(&c.LoggingLevel, "log-level", defaultLogLevel, logLevelFlagHelp)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -60,10 +60,26 @@ func (c Config) validate(appType AppType) error {
 			)
 		}
 
-		if c.PortScanRateLimit < 1 {
+		switch {
+		case c.ScanRateLimit < 1:
+			return fmt.Errorf(
+				"invalid scan rate limit value provided: %d",
+				c.ScanRateLimit,
+			)
+
+		// TODO: confirmed on Windows 10 WSLv1; may need to dynamically
+		// determine the max value based on OS API query
+		case c.ScanRateLimit >= 10000:
+			return fmt.Errorf(
+				"unreliable value provided; too high values result in 'too many open files' OS errors: %d",
+				c.ScanRateLimit,
+			)
+		}
+
+		if c.ScanRateLimit < 1 {
 			return fmt.Errorf(
 				"invalid port scan rate limit value provided: %d",
-				c.TimeoutPortScan(),
+				c.ScanRateLimit,
 			)
 		}
 


### PR DESCRIPTION
A spread of concurrency tweaks and fixes with a scattering
of other improvements. Still more to do, including
simplifying the current design.

- independent limiters for parent/child scanner goroutines
  - help prevent potential deadlock when both share the same
    rate limiter

- remove shared rate limiter from cert scanner, instead
  relying soleyly instead on the port scanner limiter in
  an effort to reduce complexity

- Add guard against potentially excessive user-provided
  scan rate limit value
  - help prevent OS errors re too many open file handles

- update .gitignore to ignore *all* vscode workspace settings
  (e.g., plugins) instead of just the main config file

- better handling of channel access, ensuring non-blocking
  access whenever not strictly required for intentional rate
  limits

- better use of WaitGroups to handle syncing between parent/child
  scanner goroutines
  - this is better than before, but subject to further
    simplification in future iterations

- increased debug logging
  - very likely excessive, logging has been significantly
    increased to help pinpoint unexpected "waits" with rate
    limiters and WaitGroups and other unexpected behavior
  - likely to be aggressively trimmed back in future iterations
    as the design stabilizes

- context handling improvements
  - cancellation handling in particular is much more reliable
  - default context timeout of 2 minutes applied for application
    - this is likely to change in the next few iterations so that
      it acts as a true inactivity timeout instead of a countdown
      timer that simply terminates the app mid-stride

- scan related config field/flags "cleanup"
  - generalize phrasing specific to port scans to instead include
    both port and cert scanning

refs GH-135