### PR TITLE
Simplify port scanning concurrency implementation

### DIFF
--- a/cmd/certsum/main.go
+++ b/cmd/certsum/main.go
@@ -77,8 +77,8 @@ func main() {
 	// from port scan limit (in an effort to avoid deadlocks)
 	hostRateLimiter := make(chan struct{}, cfg.ScanRateLimit)
 
-	// results are collected and passed per host, not per port
-	portScanResultsChan := make(chan netutils.PortCheckResults)
+	// results are collected and passed per port
+	portScanResultsChan := make(chan netutils.PortCheckResult)
 
 	certScanResultsChan := make(chan certs.DiscoveredCertChain)
 

--- a/internal/netutils/net.go
+++ b/internal/netutils/net.go
@@ -70,6 +70,11 @@ func (rs PortCheckResults) Summary() string {
 
 }
 
+// Summary generates a one-line summary of port check result.
+func (rs PortCheckResult) Summary() string {
+	return fmt.Sprintf("%v: %v", rs.Port, rs.Open)
+}
+
 // CheckPort checks whether a specified TCP port is open. Any errors
 // encountered are returned along with the port status.
 func CheckPort(host string, port int, timeout time.Duration) PortCheckResult {


### PR DESCRIPTION
Remove forced per-host results collection within port scanner and update applicable supporting goroutines to account for the change.

The net result is a simplified version of the changes made for GH-157.

refs GH-135
refs GH-157
