### PR TITLE
Add timestamp to log messages

### DIFF
--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -121,7 +121,7 @@ func (c *Config) setupLogging(appType AppType) error {
 	// email account. This approach is intended to help standardize the log
 	// messages to make them easier to search through later when
 	// troubleshooting.
-	c.Log = zerolog.New(output).With().Caller().
+	c.Log = zerolog.New(output).With().Timestamp().Caller().
 		Str("version", Version()).
 		Str("logging_level", c.LoggingLevel).
 		Str("app_type", appDescription).


### PR DESCRIPTION
I can't say with certainty, but I believe that this field was always desired and likely dropped at some point during recent refactoring. Adding it back for all project apps.