### PR TITLE
Fix Go module path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Copyright 2020 Adam Chalkley
 #
-# https:#github.com/atc0005/check-certs
+# https:#github.com/atc0005/check-cert
 #
 # Licensed under the MIT License. See LICENSE file in the project root for
 # full license information.

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,6 +1,6 @@
 # Copyright 2020 Adam Chalkley
 #
-# https:#github.com/atc0005/check-certs
+# https:#github.com/atc0005/check-cert
 #
 # Licensed under the MIT License. See LICENSE file in the project root for
 # full license information.

--- a/cmd/certsum/certcheck.go
+++ b/cmd/certsum/certcheck.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/atc0005/check-certs/internal/certs"
-	"github.com/atc0005/check-certs/internal/netutils"
+	"github.com/atc0005/check-cert/internal/certs"
+	"github.com/atc0005/check-cert/internal/netutils"
 	"github.com/rs/zerolog"
 )
 

--- a/cmd/certsum/main.go
+++ b/cmd/certsum/main.go
@@ -16,10 +16,10 @@ import (
 
 	zlog "github.com/rs/zerolog/log"
 
-	"github.com/atc0005/check-certs/internal/certs"
-	"github.com/atc0005/check-certs/internal/config"
-	"github.com/atc0005/check-certs/internal/netutils"
-	"github.com/atc0005/check-certs/internal/textutils"
+	"github.com/atc0005/check-cert/internal/certs"
+	"github.com/atc0005/check-cert/internal/config"
+	"github.com/atc0005/check-cert/internal/netutils"
+	"github.com/atc0005/check-cert/internal/textutils"
 )
 
 func main() {

--- a/cmd/certsum/portscan.go
+++ b/cmd/certsum/portscan.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/atc0005/check-certs/internal/netutils"
+	"github.com/atc0005/check-cert/internal/netutils"
 	"github.com/rs/zerolog"
 )
 

--- a/cmd/certsum/summary.go
+++ b/cmd/certsum/summary.go
@@ -8,7 +8,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/atc0005/check-certs/internal/certs"
+	"github.com/atc0005/check-cert/internal/certs"
 )
 
 func printSummaryHighLevel(

--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -15,9 +15,9 @@ import (
 
 	zlog "github.com/rs/zerolog/log"
 
-	"github.com/atc0005/check-certs/internal/certs"
-	"github.com/atc0005/check-certs/internal/config"
-	"github.com/atc0005/check-certs/internal/netutils"
+	"github.com/atc0005/check-cert/internal/certs"
+	"github.com/atc0005/check-cert/internal/config"
+	"github.com/atc0005/check-cert/internal/netutils"
 	"github.com/atc0005/go-nagios"
 )
 

--- a/cmd/fixsn/main.go
+++ b/cmd/fixsn/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/atc0005/check-certs/internal/certs"
+	"github.com/atc0005/check-cert/internal/certs"
 )
 
 func main() {

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -19,10 +19,10 @@ import (
 
 	"github.com/grantae/certinfo"
 
-	"github.com/atc0005/check-certs/internal/certs"
-	"github.com/atc0005/check-certs/internal/config"
-	"github.com/atc0005/check-certs/internal/netutils"
-	"github.com/atc0005/check-certs/internal/textutils"
+	"github.com/atc0005/check-cert/internal/certs"
+	"github.com/atc0005/check-cert/internal/config"
+	"github.com/atc0005/check-cert/internal/netutils"
+	"github.com/atc0005/check-cert/internal/textutils"
 	"github.com/atc0005/go-nagios"
 )
 

--- a/cmd/range/main.go
+++ b/cmd/range/main.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/atc0005/check-certs/internal/netutils"
+	"github.com/atc0005/check-cert/internal/netutils"
 )
 
 // Purpose: Proof of concept for new partial range syntax. Based heavily off

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/atc0005/check-certs
+module github.com/atc0005/check-cert
 
 go 1.14
 

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atc0005/check-certs/internal/textutils"
+	"github.com/atc0005/check-cert/internal/textutils"
 	"github.com/atc0005/go-nagios"
 )
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,8 +15,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/atc0005/check-certs/internal/netutils"
-	"github.com/atc0005/check-certs/internal/textutils"
+	"github.com/atc0005/check-cert/internal/netutils"
+	"github.com/atc0005/check-cert/internal/textutils"
 	"github.com/rs/zerolog"
 )
 


### PR DESCRIPTION
At some point the repo was named check-certs instead of check-cert. When the rename occurred I forgot to update the Go module path accordingly. This commit sorts that omission.