### PR TITLE
Refactor certs state identification

### DIFF
--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -183,7 +183,7 @@ func main() {
 
 				fmt.Printf(
 					"- %s: %v \n", err,
-					certsSummary.ServiceCheckStatus,
+					certsSummary.ServiceState().Label,
 				)
 			}
 
@@ -192,19 +192,13 @@ func main() {
 
 	nextToExpire := fmt.Sprintf(
 		"- %s",
-		certs.OneLineCheckSummary(
-			certsSummary.ServiceCheckStatus,
-			certChain,
-			// Leave off summary/overview as we'll emit it separately
-			// certsSummary.Summary,
-			"",
-		),
+		certs.OneLineCheckSummary(certsSummary, false),
 	)
 	fmt.Println(nextToExpire)
 
 	statusOverview := fmt.Sprintf(
 		"- %s: %s",
-		certsSummary.ServiceCheckStatus,
+		certsSummary.ServiceState().Label,
 		certsSummary.Summary,
 	)
 	fmt.Println(statusOverview)
@@ -212,9 +206,7 @@ func main() {
 	textutils.PrintHeader("CERTIFICATES | CHAIN DETAILS")
 
 	fmt.Println(certs.GenerateCertsReport(
-		certChain,
-		certsExpireAgeCritical,
-		certsExpireAgeWarning,
+		certsSummary,
 	))
 
 	if cfg.EmitCertText {


### PR DESCRIPTION
- Extend `ChainStatus` type to bundle cert chain and threshold
  values
- Replace `ServiceCheckStatus` field in `ChainStatus` type with
  method to provide this text label in addition to the appropriate
  exit code
- Simplify `GenerateCertsReport()` func to only require a
  `ChainStatus` instead of multiple arguments
- Update `OneLineCheckSummary()` so that an optional flag can be
  provided to toggle overall cert chain summary text and so that
  multiple other arguments are now replaced by a `ChainStatus`
  value
- Provide and use `IsCriticalState()`, `IsWarningState()` and
  `IsOKState` `ChainStatus` methods to simplify and fix the logic
  for determining the final exit status for the service check.

refs GH-188