### PR TITLE
Fix inconsistent formatting of lscert headers

### DIFF
--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -108,7 +108,7 @@ func main() {
 
 	textutils.PrintHeader("CERTIFICATES | AGE THRESHOLDS")
 	fmt.Printf(
-		"\n- %s:\tExpires before %v (%d days)\n",
+		"- %s:\tExpires before %v (%d days)\n",
 		nagios.StateWARNINGLabel,
 		certsExpireAgeWarning.Format(certs.CertValidityDateLayout),
 		cfg.AgeWarning,
@@ -134,7 +134,7 @@ func main() {
 	}
 
 	fmt.Printf(
-		"\n- %s: %d certs found for %s\n",
+		"- %s: %d certs found for %s\n",
 		nagios.StateOKLabel,
 		certsSummary.TotalCertsCount,
 		certChainSource,

--- a/internal/textutils/textutils.go
+++ b/internal/textutils/textutils.go
@@ -68,12 +68,12 @@ func LowerCaseStringSlice(xs []string) []string {
 	return lxs
 }
 
-// PrintHeader printers a section header to help separate otherwise
-// potentially dense blocks of text.
+// PrintHeader prints a section header with liberal leading and trailing
+// newlines to help separate otherwise potentially dense blocks of text.
 func PrintHeader(headerText string) {
 	headerBorderStr := strings.Repeat("=", len(headerText))
 	fmt.Printf(
-		"\n\n%s\n%s\n%s\n",
+		"\n\n%s\n%s\n%s\n\n",
 		headerBorderStr,
 		headerText,
 		headerBorderStr,


### PR DESCRIPTION
Move whitespace handling before/after header generation from main lscert app to the `textutils.PrintHeader()` func. This fixes the mismatch between earlier headers and later ones for cert chain and (potential) unparsed cert file data.

fixes GH-203