### PR TITLE
Add missing cert file eval support to feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ of detail in the provided output.
     - verify local certificate "bundle" or standalone leaf certificate file
   - `check_cert` Nagios plugin
     - verify certificate used by specified service
+    - verify local certificate "bundle" or standalone leaf certificate file
   - `certsum` CLI tool
     - generate summary of discovered certificates from given hosts (single or
       IP Address ranges, hostnames or FQDNs) and ports


### PR DESCRIPTION
The recent work to add this support to the `check_cert`
plugin was not noted as intended.

refs GH-193