### PR TITLE
Redirect help output from stderr to stdout

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -307,6 +307,12 @@ type Config struct {
 // Usage is a custom override for the default Help text provided by the flag
 // package. Here we prepend some additional metadata to the existing output.
 var Usage = func() {
+
+	// Override default of stderr as destination for help output. This allows
+	// Nagios XI and similar monitoring systems to call plugins with the
+	// `--help` flag and have it display within the Admin web UI.
+	flag.CommandLine.SetOutput(os.Stdout)
+
 	fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
 	fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
 	flag.PrintDefaults()


### PR DESCRIPTION
Send output to stdout so that Nagios XI (and presumably similar
systems) can poll plugins from this project for their help
output and display within the admin web UI.

fixes GH-248