### PR TITLE
Update output for hostname verification failure

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -265,8 +265,8 @@ func main() {
 						nagios.CheckOutputEOL +
 						"As a temporary workaround, you can" +
 						" use v0.5.3 of this plugin, rebuild this plugin" +
-						" using Go 1.16 or specify the flag to ignore hostname" +
-						" verification errors if the SANs list is found to be empty." +
+						" using Go 1.16 or specify the flag to skip hostname" +
+						" verification if the SANs list is found to be empty." +
 						nagios.CheckOutputEOL +
 						nagios.CheckOutputEOL +
 						"See these resources for additional information: " +


### PR DESCRIPTION
Note that the flag is used to skip hostname verification if the SANs list is found to be empty, not ignore errors
that occur. This text is a holdover from an earlier iteration that I abandoned.

refs GH-276