### PR TITLE
Update certsum to use SNI support

### DIFF
--- a/cmd/certsum/main.go
+++ b/cmd/certsum/main.go
@@ -48,13 +48,13 @@ func main() {
 		Str("app_timeout", fmt.Sprintf("%v", cfg.TimeoutAppInactivity())).
 		Logger()
 
-	givenIPsList := cfg.IPAddresses()
-	log.Debug().Msgf("IP Addresses before deduping: %v", givenIPsList)
-	log.Debug().Msgf("Total IPs from all ranges before deduping: %d", len(givenIPsList))
+	expandedHostsList := cfg.Hosts()
+	log.Debug().Msgf("Host values before deduping: %v", expandedHostsList)
+	log.Debug().Msgf("Total host values before deduping: %d", len(expandedHostsList))
 
-	ipsList := textutils.DedupeList(givenIPsList)
-	log.Debug().Msgf("Total IPs from all ranges after deduping: %d", len(ipsList))
-	log.Debug().Msgf("IP Addresses after deduping: %v", ipsList)
+	expandedHostsList = textutils.DedupeList(expandedHostsList)
+	log.Debug().Msgf("Total host values after deduping: %d", len(expandedHostsList))
+	log.Debug().Msgf("Host values after deduping: %v", expandedHostsList)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -99,7 +99,7 @@ func main() {
 	log.Debug().Msg("Starting portScanner")
 	go portScanner(
 		ctx,
-		cfg.IPAddresses(),
+		cfg.Hosts(),
 		cfg.CertPorts(),
 		cfg.TimeoutPortScan(),
 		portScanResultsChan,
@@ -126,7 +126,7 @@ func main() {
 
 	fmt.Printf(
 		"Beginning cert scan against %d unique hosts using ports: %v\n",
-		len(ipsList),
+		len(expandedHostsList),
 		cfg.CertPorts(),
 	)
 

--- a/cmd/certsum/summary.go
+++ b/cmd/certsum/summary.go
@@ -42,7 +42,7 @@ func printSummaryHighLevel(
 
 	// Header row in output
 	fmt.Fprintf(tw,
-		"IP Address\tPort\tSubject or SANs\tStatus\tChain Summary\tSerial\n")
+		"Host\tPort\tSubject or SANs\tStatus\tChain Summary\tSerial\n")
 
 	// Separator row
 	fmt.Fprintln(tw,
@@ -133,7 +133,7 @@ func printSummaryDetailedLevel(
 
 	// Header row in output
 	fmt.Fprintf(tw,
-		"IP Address\tPort\tSubject or SANs\tStatus (Type)\tSummary\tSerial\n")
+		"Host\tPort\tSubject or SANs\tStatus (Type)\tSummary\tSerial\n")
 
 	// Separator row
 	fmt.Fprintln(tw,

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -38,7 +38,7 @@ import (
 )
 
 // DiscoveredCertChain is a poorly named type that represents the certificate
-// chain found on a specific host along with that hosts IP/Name and port.
+// chain found on a specific host along with that host's IP/Name and port.
 type DiscoveredCertChain struct {
 	Host  string
 	Port  int

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -40,9 +40,10 @@ func (c Config) CertPorts() []int {
 	return []int{defaultPortsListEntry}
 }
 
-// IPAddresses returns a list of individual IP Addresses expanded from any
-// user-specified IP Addresses (single or ranges), hostnames or FQDNs.
-func (c Config) IPAddresses() []string {
+// Hosts returns a list of individual IP Addresses expanded from any
+// user-specified IP Addresses (single or ranges) and hostnames or FQDNs that
+// passed name resolution checks.
+func (c Config) Hosts() []string {
 	if c.hosts.expanded != nil {
 		return c.hosts.expanded
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -106,8 +106,8 @@ func (c Config) validate(appType AppType) error {
 			)
 		}
 
-		if c.IPAddresses() == nil {
-			return fmt.Errorf("IP Addresses (one or many, single or ranges) not provided")
+		if c.Hosts() == nil {
+			return fmt.Errorf("host values (one or many, single or IP Address ranges) not provided")
 		}
 
 		// TODO: Figure out how to (or if we need to) validate mix of boolean

--- a/internal/netutils/types.go
+++ b/internal/netutils/types.go
@@ -9,13 +9,25 @@ package netutils
 
 import "net"
 
-// PortCheckResult indicates whether a TCP port is open and what error (if
-// any) occurred checking the port.
+// PortCheckResult indicates the discovered TCP port state for a given host
+// and what error (if any) occurred while checking the port.
 type PortCheckResult struct {
+	// Host is the hostname, FQDN or IP Address value used to evaluate the TCP
+	// port state.
+	Host string
+
+	// IPAddress represents the address of an IP end point.
 	IPAddress net.IPAddr
-	Port      int
-	Open      bool
-	Err       error
+
+	// Port is the specific TCP port evaluated on a host.
+	Port int
+
+	// Open indicates whether a TCP port was found to be open during a port
+	// check.
+	Open bool
+
+	// Err is what error (if any) which occurred while checking a TCP port.
+	Err error
 }
 
 // PortCheckResults is a collection of PortCheckResult intended for bulk


### PR DESCRIPTION
## OVERVIEW

- Add SNI support by using hostname (where provided) for cert
  evaluation
- List host (where provided) in report output instead of IP Address to
  indicate which host was evaluated

## CHANGES

- Misc doc comment fixes/clarifications
- Add and use new sentinel errors in `netutils` package in an effort
  to provide "hooks" into the underlying cause for various problems
  encountered while processing IP Addresses
- Broad replacement of variables indicating IP Addresses with
  variables generically indicating hosts or "targets" (since both IP
  Addresses and host values are now used internally)
- Expand `netutils.PortCheckResult` type to track host value
  separately from the `net.IPAddr` type
- Update cert scanning/evaluation logic to use host value instead of
  IP Address if available (SNI support)
- Add minor input validation for `netutils.GetCerts()`
- Rework `netutils.ExpandIPAddress()` so that instead of returning
  resolved hostname values we return the confirmed *resolvable*
  hostname instead (in order to provide SNI support during cert
  retrieval)
- Rename `Config.IPAddresses()` method to `Config.Hosts()` since the
  logic is no longer specific to IP Addresses
- Replace column header "IP Address" with "Host" in final output to
  indicate that an evaluated host can be based on either of IP Address
  or Hostname

## REFERENCES

- fixes GH-273
- fixes GH-272