### PR TITLE
Fix empty host value by returning full port state

### DIFF
--- a/cmd/certsum/certcheck.go
+++ b/cmd/certsum/certcheck.go
@@ -144,6 +144,9 @@ func certScanner(
 				continue
 			}
 
+			// The host value is set even if there was an issue encountered
+			// checking a port's status so that we can provide a brief summary
+			// of the port check results.
 			var hostValue string
 			switch {
 			case portScanResult.Host != "":

--- a/cmd/certsum/portscan.go
+++ b/cmd/certsum/portscan.go
@@ -165,24 +165,14 @@ func portScanner(
 
 					log.Debug().Msgf("Checking %v", target)
 					portState := netutils.CheckPort(target, port, scanTimeout)
-					if portState.Err != nil {
-						// TODO: Check specific error type to determine how to
-						// proceed. For now, we'll just assume that we're dealing
-						// with a timeout, emit the error as a debug message and
-						// continue.
-						log.Debug().
-							Str("host", target).
-							Int("port", port).
-							Err(portState.Err).
-							Msg("")
 
-						// indicate that the port was found to be closed
-						portScanResultsChan <- netutils.PortCheckResult{
-							Err: portState.Err,
-						}
-
-						return
-					}
+					// if portState.Err != nil {
+					//
+					//
+					// TODO: Check specific error type to determine whether a
+					// port scan attempt should be retried.
+					//
+					// }
 
 					log.Debug().
 						Str("hostname", portState.Host).

--- a/internal/netutils/net.go
+++ b/internal/netutils/net.go
@@ -96,6 +96,9 @@ func (rs PortCheckResult) Summary() string {
 // CheckPort checks whether a specified TCP port for a given host is open. The
 // given host must be either a valid, resolvable hostname or a valid IP
 // Address. Any errors encountered are returned along with the port status.
+//
+// NOTE: This function explicitly returns real values for host & port instead
+// of zero values so that they may be used in summary output by callers.
 func CheckPort(host string, port int, timeout time.Duration) PortCheckResult {
 
 	if strings.TrimSpace(host) == "" {


### PR DESCRIPTION
Instead of only returning a partial set of values, return the
`netutils.PortCheckResult` value as-is for potential emission
as summary output.

This resolves the empty host value shown when an attempt to
connect to a port fails.

This logic will likely need further review/refactoring to
better communicate open/closed status.

fixes GH-290