### PR TITLE
Fix SNI support, list IP/host where cert retrieved

### DIFF
--- a/cmd/certsum/certcheck.go
+++ b/cmd/certsum/certcheck.go
@@ -208,16 +208,14 @@ func certScanner(
 						Int("port", portScanResult.Port).
 						Msg("Retrieving certificate chain")
 
-					var hostValue string
-					switch {
-					case strings.TrimSpace(portScanResult.Host) != "":
-						hostValue = portScanResult.Host
-					default:
-						hostValue = portScanResult.IPAddress.String()
-					}
-
+					// NOTE: We explicitly specify the IP Address to prevent
+					// earlier port check results from occurring on one IP
+					// while we unintentionally connect to another IP (by way
+					// of using a name/FQDN to open the connection) to
+					// retrieve the certificate chain.
 					certChain, certFetchErr := netutils.GetCerts(
-						hostValue,
+						portScanResult.Host,
+						portScanResult.IPAddress.String(),
 						portScanResult.Port,
 						timeout,
 						log,
@@ -230,7 +228,8 @@ func certScanner(
 						}
 						log.Error().
 							Err(certFetchErr).
-							Str("host", hostValue).
+							Str("host", portScanResult.Host).
+							Str("ip_address", portScanResult.IPAddress.String()).
 							Int("port", portScanResult.Port).
 							Msg("error fetching certificates chain")
 

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -37,8 +37,8 @@ import (
 	"github.com/atc0005/go-nagios"
 )
 
-// DiscoveredCertChain is a poorly named type that represents the certificate
-// chain found on a specific host along with that host's IP/Name and port.
+// DiscoveredCertChain represents the certificate chain found on a specific
+// host along with that host's IP/Name and port.
 type DiscoveredCertChain struct {
 	// Name is the hostname or FQDN of a system where a certificate chain was
 	// retrieved. Depending on how scan targets were specified, this value may


### PR DESCRIPTION
## Overview

Previously, there was potential for checking a server's port status
using one IP and attempting to retrieve the certificate chain from
another IP Address (due to how the host value was used for cert
retrieval). To provide reliable SNI support we now explicitly specify
both host name/FQDN (if available) and IP Address of target server
when we attempt to retrieve the certificate chain. We set the host
name/FQDN in the client TLS configuration and use the IP Address to
open the connection.

The `lscert` and `check_cert` tools now also explicitly note the host
value and IP Address in summary output.

## Changes

- add misc debug log statements where previously missing
- expand given host patterns and explicitly use the first resolved IP
  for opening a connection to remote server for cert retrieval
- explicitly note when a host pattern resolves to multiple IPs
  (`lscert`, `check_cert`)
- update `netutils.GetCerts()`
  - accept optional host value and required IP Address (as string) in
  order to ensure that cert chain is retrieved from the same IP
  Address that was picked (and logged) earlier
  - explicitly use given host Name or FQDN in client's handshake to
    support virtual hosting (SNI)
  - improve connection error message to note host value and IP Address
    used in cert chain retrieval attempt
- Replace logger WARNING regarding hostname mismatch with
  `fmt.Printf()` statement in order to match existing formatting
  (`lscert`)

## Known Issues

The README coverage has not yet been updated to reflect the changes
noted here, including the various examples/output.

## References

- fixes GH-282
- GH-294
- GH-289