### PR TITLE
Drop log level of "multiple IPs" message

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -220,11 +220,11 @@ func main() {
 				ipAddrs.Str(ip)
 			}
 
-			log.Warn().
+			log.Debug().
 				Int("num_ip_addresses", len(expandedHost[0].Expanded)).
 				Array("ip_addresses", ipAddrs).
 				Msg("Multiple IP Addresses resolved from given host pattern")
-			log.Warn().Msg("Using first IP Address, ignoring others")
+			log.Debug().Msg("Using first IP Address, ignoring others")
 		}
 
 		// Grab first IP Address from the resolved collection. We'll

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -107,11 +107,11 @@ func main() {
 				ipAddrs.Str(ip)
 			}
 
-			log.Warn().
+			log.Debug().
 				Int("num_ip_addresses", len(expandedHost[0].Expanded)).
 				Array("ip_addresses", ipAddrs).
 				Msg("Multiple IP Addresses resolved from given host pattern")
-			log.Warn().Msg("Using first IP Address, ignoring others")
+			log.Debug().Msg("Using first IP Address, ignoring others")
 
 		}
 


### PR DESCRIPTION
Reduce from WARNING to DEBUG since there are many legitimate scenarios where this is to be expected.

fixes GH-300