### PR TITLE
Fix `netutils.DedupeHosts()` logic, intro details

### DIFF
--- a/cmd/certsum/main.go
+++ b/cmd/certsum/main.go
@@ -124,7 +124,14 @@ func main() {
 	)
 
 	fmt.Printf(
-		"Beginning cert scan against %d unique hosts using ports: %v\n",
+		"Beginning cert scan against %d IPs expanded from %d unique host patterns using ports: %v\n",
+		func() int {
+			var targetIPs int
+			for _, host := range expandedHostsList {
+				targetIPs += len(host.Expanded)
+			}
+			return targetIPs
+		}(),
 		len(expandedHostsList),
 		cfg.CertPorts(),
 	)

--- a/internal/netutils/net.go
+++ b/internal/netutils/net.go
@@ -622,8 +622,8 @@ func DedupeHosts(hosts []HostPattern) []HostPattern {
 	uniqHosts := make([]HostPattern, 0, len(hosts))
 
 	for _, host := range hosts {
-		if val, inMap := uniqHostsIdx[host.Given]; !inMap {
-			uniqHosts = append(uniqHosts, val)
+		if _, inMap := uniqHostsIdx[host.Given]; !inMap {
+			uniqHosts = append(uniqHosts, host)
 		}
 		uniqHostsIdx[host.Given] = host
 	}


### PR DESCRIPTION
- update `netutils.DedupeHosts()` logic to record new hosts
  directly instead of attempting to use a non-existent map
  value (had the logic inverted)
- update intro text to note unique host patterns and expanded
  scan targets, the latter being potentially more relevant in
  terms of expected scan queue depth

refs GH-292