### PR TITLE
Update hostname verification failure suggestion

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -422,11 +422,11 @@ func main() {
 				nagiosExitState.LongServiceOutput =
 					"Consider updating the service check or command " +
 						"definition to specify the website FQDN instead of " +
-						"the host FQDN as the 'server' flag value. " +
+						"the host FQDN as the 'dns-name' (or 'server') flag value. " +
 						"E.g., use 'www.example.org' instead of " +
 						"'host7.example.com' in order to allow the remote " +
 						"server to select the correct certificate instead " +
-						"of the certificate for the first website in its list."
+						"of using the default certificate."
 
 				return
 


### PR DESCRIPTION
Emphasize supplying the expected FQDN associated with the certificate via the `dns-name` flag or the `server` flag instead of using the server FQDN.

The prior wording omitted mention of the `dns-name` flag.