### PR TITLE
Fix IP Address range expansion & update handling

### DIFF
--- a/cmd/certsum/main.go
+++ b/cmd/certsum/main.go
@@ -98,7 +98,7 @@ func main() {
 	log.Debug().Msg("Starting portScanner")
 	go portScanner(
 		ctx,
-		cfg.Hosts(),
+		expandedHostsList,
 		cfg.CertPorts(),
 		cfg.TimeoutPortScan(),
 		portScanResultsChan,

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -79,7 +79,9 @@ func main() {
 		log.Debug().Msg("Attempting to retrieve certificates from server")
 
 		// We should only have one expanded host value from one given host
-		// pattern (since IP ranges are not valid server flag input values).
+		// pattern. If a resolvable name is given, we may have several IP
+		// Addresses returned. If a range is specified the results are
+		// unspecified.
 		expandedHost, expandErr := netutils.ExpandHost(cfg.Server)
 		switch {
 		case expandErr != nil:
@@ -87,28 +89,30 @@ func main() {
 				"error expanding given host pattern")
 			os.Exit(1)
 
-		case len(expandedHost) > 1:
+		// Fail early for IP Ranges. While we could just grab the first
+		// expanded IP Address, this may be a potential source of confusion
+		// best avoided.
+		case expandedHost.Range:
 			log.Error().Msgf(
-				"given host pattern invalid; "+
-					"host pattern expands to %d host values; only one expected",
-				len(expandedHost),
+				"given host pattern invalid; " +
+					"host pattern is a CIDR or partial IP range",
 			)
 			os.Exit(1)
 
-		case len(expandedHost[0].Expanded) == 0:
+		case len(expandedHost.Expanded) == 0:
 			log.Error().Msg(
 				"error expanding given host value to IP Address")
 			os.Exit(1)
 
-		case len(expandedHost[0].Expanded) > 1:
+		case len(expandedHost.Expanded) > 1:
 
 			ipAddrs := zerolog.Arr()
-			for _, ip := range expandedHost[0].Expanded {
+			for _, ip := range expandedHost.Expanded {
 				ipAddrs.Str(ip)
 			}
 
 			log.Debug().
-				Int("num_ip_addresses", len(expandedHost[0].Expanded)).
+				Int("num_ip_addresses", len(expandedHost.Expanded)).
 				Array("ip_addresses", ipAddrs).
 				Msg("Multiple IP Addresses resolved from given host pattern")
 			log.Debug().Msg("Using first IP Address, ignoring others")
@@ -116,12 +120,12 @@ func main() {
 		}
 
 		// Grab first IP Address from the resolved collection.
-		ipAddr := expandedHost[0].Expanded[0]
+		ipAddr := expandedHost.Expanded[0]
 
 		var hostVal string
 		switch {
-		case expandedHost[0].Resolved:
-			hostVal = expandedHost[0].Given
+		case expandedHost.Resolved:
+			hostVal = expandedHost.Given
 			certChainSource = fmt.Sprintf(
 				"service running on %s (%s) at port %d",
 				hostVal,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,12 +143,12 @@ func (mvh *multiValueHostsFlag) Set(value string) error {
 	}
 
 	// convert given host patterns
-	for _, hostPattern := range items {
-		hosts, err := netutils.ExpandHost(hostPattern)
+	for _, givenPattern := range items {
+		host, err := netutils.ExpandHost(givenPattern)
 		if err != nil {
 			return err
 		}
-		mvh.hostValues = append(mvh.hostValues, hosts...)
+		mvh.hostValues = append(mvh.hostValues, host)
 	}
 
 	return nil

--- a/internal/netutils/types.go
+++ b/internal/netutils/types.go
@@ -78,4 +78,8 @@ type HostPattern struct {
 	// hostname or FQDN values which successfully resolve to one or more IP
 	// Addresses.
 	Resolved bool
+
+	// Range indicates whether the given host pattern was determined to be a
+	// CIDR or partial IP Address range.
+	Range bool
 }


### PR DESCRIPTION
- add `(netutils.HostPattern).Range` field to track whether a given
  host pattern is determined to be a CIDR or partial IP Address range
  so that we can potentially have client code apply different behavior
  depending on whether ranges were given
- change signature of `netutils.ExpandHost()` so that instead of a
  collection of HostPattern values being returned we acknowledge that
  we should only ever return one HostPattern value that *wraps* the
  potential for multiple expanded IP Addresses for a given host
  pattern
- collect range expansion values into one slice before bundling as a
  new HostPattern value (instead of returning multiple HostPattern
  values with one IP in the Expanded collection)
- update `lscert`, `check_cert` to expect a single HostPattern return
  value instead of a collection
- update `lscert`, `check_cert` to explicitly reject CIDR or partial
  IP Address range host patterns
- update `certsum` so that the deduped hosts list is used by the port
  scanner goroutine instead of the original (non-deduped) list

refs GH-292