### PR TITLE
Update summary cert chain count desc/label

### DIFF
--- a/cmd/certsum/summary.go
+++ b/cmd/certsum/summary.go
@@ -24,7 +24,7 @@ func printSummaryHighLevel(
 
 	certIssuesCount := discoveredChains.NumProblems(certsExpireAgeCritical, certsExpireAgeWarning)
 
-	fmt.Printf("%d certificates (%d issues) found.\n", len(discoveredChains), certIssuesCount)
+	fmt.Printf("%d certificate chains (%d issues) found.\n", len(discoveredChains), certIssuesCount)
 
 	if certIssuesCount == 0 && !showAllHosts {
 		fmt.Printf("\nResults: No certificate issues found!\n")
@@ -152,7 +152,7 @@ func printSummaryDetailedLevel(
 
 	certIssuesCount := discoveredChains.NumProblems(certsExpireAgeCritical, certsExpireAgeWarning)
 
-	fmt.Printf("%d certificates (%d issues) found.\n", len(discoveredChains), certIssuesCount)
+	fmt.Printf("%d certificate chains (%d issues) found.\n", len(discoveredChains), certIssuesCount)
 
 	if certIssuesCount == 0 && !showAllCerts {
 		fmt.Printf("\nResults: No certificate issues found!\n")


### PR DESCRIPTION
Refer to the number of discovered certificate chains *as* chains instead of just "certificates". If we're going to note the total certificates discovered we'll need to count each link in all discovered chains, which we're not yet listing.