### PR TITLE
certsum | remove invalid `filename` logger field

### DIFF
--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -148,7 +148,6 @@ func (c *Config) setupLogging(appType AppType) error {
 			Str("version", Version()).
 			Str("logging_level", c.LoggingLevel).
 			Str("app_type", appTypeScanner).
-			Str("filename", c.Filename).
 			Array("ports", ports).
 			Str("cert_check_timeout", c.Timeout().String()).
 			Int("age_warning", c.AgeWarning).


### PR DESCRIPTION
The `Config.Filename` field is always empty for the `certsum` tool as that tool does not accept that flag.

fixes GH-312