### PR TITLE
lscert | Verify hostname if dns-name flag is used

### DIFF
--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -203,26 +203,24 @@ func main() {
 		certChainSource,
 	)
 
-	if cfg.Server != "" {
+	// Apply hostname verification if we're evaluating a remote server OR if
+	// the user has explicitly specified a DNSName value for that purpose.
+	if cfg.Server != "" || cfg.DNSName != "" {
 
-		if len(certChain) > 0 {
-
-			hostnameValueToUse := cfg.Server
-
-			// Allow user to explicitly specify which hostname should be used
-			// for comparison against the leaf certificate.
-			if cfg.DNSName != "" {
-				hostnameValueToUse = cfg.DNSName
-			}
-
-			// verify leaf certificate is valid for the provided server FQDN
-			if err := certChain[0].VerifyHostname(hostnameValueToUse); err != nil {
-				fmt.Printf("- WARNING: Provided hostname %q does not match server certificate: %v\n", hostnameValueToUse, err)
-			} else {
-				fmt.Println("- OK: Provided hostname matches discovered certificate")
-			}
+		// While we default to using the server FQDN or IP Address used to
+		// make the connection as our hostname value, we allow the user to
+		// explicitly specify which hostname should be used for comparison
+		// against the leaf certificate.
+		hostnameValueToUse := cfg.Server
+		if cfg.DNSName != "" {
+			hostnameValueToUse = cfg.DNSName
 		}
 
+		if err := certChain[0].VerifyHostname(hostnameValueToUse); err != nil {
+			fmt.Printf("- WARNING: Provided hostname %q does not match server certificate: %v\n", hostnameValueToUse, err)
+		} else {
+			fmt.Printf("- OK: Provided hostname %q matches discovered certificate\n", hostnameValueToUse)
+		}
 	}
 
 	// check SANS entries if provided via command-line


### PR DESCRIPTION
In addition to verifying the hostname when the `server` flag is specified, also apply hostname verification for a certificate if the `dns-name` flag is used. This matches the logic already used by the check_cert tool.

refs GH-315