### PR TITLE
check_cert | Move lead-in text up

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -310,6 +310,19 @@ func main() {
 		return
 	}
 
+	// Prepend a baseline lead-in that summarizes the number of certificates
+	// retrieved and from which target host/IP Address.
+	defer func() {
+		nagiosExitState.LongServiceOutput = fmt.Sprintf(
+			"%d certs found for %s%s%s%s",
+			certsSummary.TotalCertsCount,
+			certChainSource,
+			nagios.CheckOutputEOL,
+			nagios.CheckOutputEOL,
+			nagiosExitState.LongServiceOutput,
+		)
+	}()
+
 	if certsSummary.TotalCertsCount > 0 {
 
 		hostnameValue := cfg.Server
@@ -440,19 +453,6 @@ func main() {
 		}
 
 	}
-
-	// Prepend a baseline lead-in that summarizes the number of certificates
-	// retrieved and from which target host/IP Address.
-	defer func() {
-		nagiosExitState.LongServiceOutput = fmt.Sprintf(
-			"%d certs found for %s%s%s%s",
-			certsSummary.TotalCertsCount,
-			certChainSource,
-			nagios.CheckOutputEOL,
-			nagios.CheckOutputEOL,
-			nagiosExitState.LongServiceOutput,
-		)
-	}()
 
 	// check SANS entries if provided via command-line
 	if len(cfg.SANsEntries) > 0 {


### PR DESCRIPTION
Move lead-in text immediately after retrieving the certificate chain so that those details are provided regardless of whether hostname verification is successful.

fixes GH-316