### PR TITLE
Tweak wording regarding certificate source

### DIFF
--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -220,9 +220,9 @@ func main() {
 		}
 
 		if err := certChain[0].VerifyHostname(hostnameValueToUse); err != nil {
-			fmt.Printf("- WARNING: Provided hostname %q does not match server certificate: %v\n", hostnameValueToUse, err)
+			fmt.Printf("- WARNING: Provided hostname %q does not match evaluated certificate: %v\n", hostnameValueToUse, err)
 		} else {
-			fmt.Printf("- OK: Provided hostname %q matches discovered certificate\n", hostnameValueToUse)
+			fmt.Printf("- OK: Provided hostname %q matches evaluated certificate\n", hostnameValueToUse)
 		}
 	}
 


### PR DESCRIPTION
Because the cert may come from a file or a remote system replace mix of "server" and "discovered" with "evaluated" to consistently cover both scenarios.

refs GH-315