### PR TITLE
Fix lscert SANs service state label position

### DIFF
--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -243,8 +243,9 @@ func main() {
 					Msg("SANs entries mismatch")
 
 				fmt.Printf(
-					"- %s: %v \n", err,
+					"- %s: %v \n",
 					certsSummary.ServiceState().Label,
+					err,
 				)
 			}
 


### PR DESCRIPTION
Place the state label before the error message as intended.

fixes GH-323