### PR TITLE
Fix incorrect state label for SANs list mismatch

### DIFF
--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -244,7 +244,7 @@ func main() {
 
 				fmt.Printf(
 					"- %s: %v \n",
-					certsSummary.ServiceState().Label,
+					nagios.StateCRITICALLabel,
 					err,
 				)
 			}


### PR DESCRIPTION
Set explicit state label instead of relying on not yet supported dynamic state label/exit code support for SANs list mismatch scenario.

fixes GH-328
refs GH-211