### PR TITLE
Fix exit state status code for SANs list mismatch

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -476,7 +476,7 @@ func main() {
 					mismatched,
 				)
 
-				nagiosExitState.ExitStatusCode = nagios.StateWARNINGExitCode
+				nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 				log.Warn().
 					Err(nagiosExitState.LastError).
 					Int("sans_entries_requested", len(cfg.SANsEntries)).


### PR DESCRIPTION
Label indicated CRITICAL state, but exit code was WARNING. Changed so that both label and exit code are of CRITICAL state.

fixes GH-329