### PR TITLE
Fix incorrect SANs list calculations

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -461,7 +461,8 @@ func main() {
 		firstSANsEntry := strings.ToLower(strings.TrimSpace(cfg.SANsEntries[0]))
 		if firstSANsEntry != strings.ToLower(strings.TrimSpace(config.SkipSANSCheckKeyword)) {
 
-			if mismatched, err := certs.CheckSANsEntries(certChain[0], certChain, cfg.SANsEntries); err != nil {
+			mismatched, found, err := certs.CheckSANsEntries(certChain[0], certChain, cfg.SANsEntries)
+			if err != nil {
 
 				nagiosExitState.LastError = err
 
@@ -480,12 +481,17 @@ func main() {
 				log.Warn().
 					Err(nagiosExitState.LastError).
 					Int("sans_entries_requested", len(cfg.SANsEntries)).
-					Int("sans_entries_found", len(certChain)).
+					Int("sans_entries_found", found).
 					Msg("SANs entries mismatch")
 
 				return
 
 			}
+
+			log.Debug().
+				Int("sans_entries_requested", len(cfg.SANsEntries)).
+				Int("sans_entries_found", found).
+				Msg("SANs entries match")
 		}
 	}
 

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -233,21 +233,29 @@ func main() {
 		firstSANsEntry := strings.ToLower(strings.TrimSpace(cfg.SANsEntries[0]))
 		if firstSANsEntry != strings.ToLower(strings.TrimSpace(config.SkipSANSCheckKeyword)) {
 
-			if mismatched, err := certs.CheckSANsEntries(certChain[0], certChain, cfg.SANsEntries); err != nil {
+			mismatched, found, err := certs.CheckSANsEntries(certChain[0], certChain, cfg.SANsEntries)
+			switch {
+			case err != nil:
 
 				log.Debug().
 					Err(err).
 					Int("sans_entries_requested", len(cfg.SANsEntries)).
-					Int("sans_entries_found", len(certChain)).
+					Int("sans_entries_found", found).
 					Int("sans_entries_mismatched", mismatched).
 					Msg("SANs entries mismatch")
+			default:
 
-				fmt.Printf(
-					"- %s: %v \n",
-					nagios.StateCRITICALLabel,
-					err,
-				)
+				log.Debug().
+					Int("sans_entries_requested", len(cfg.SANsEntries)).
+					Int("sans_entries_found", found).
+					Msg("SANs entries match")
 			}
+
+			fmt.Printf(
+				"- %s: %v \n",
+				nagios.StateCRITICALLabel,
+				err,
+			)
 
 		}
 	}


### PR DESCRIPTION
- update `certs.CheckSANsEntries()` to return the number of
  total SANs entries found across all certs in the chain
- update call sites to expect/use updated return values from
  `certs.CheckSANsEntries()` function
- add success branch requested/found debug logging call

fixes GH-327