### PR TITLE
Emit correct success/fail SANs eval message

### DIFF
--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -243,19 +243,25 @@ func main() {
 					Int("sans_entries_found", found).
 					Int("sans_entries_mismatched", mismatched).
 					Msg("SANs entries mismatch")
+
+				fmt.Printf(
+					"- %s: %v \n",
+					nagios.StateCRITICALLabel,
+					err,
+				)
+
 			default:
 
 				log.Debug().
 					Int("sans_entries_requested", len(cfg.SANsEntries)).
 					Int("sans_entries_found", found).
 					Msg("SANs entries match")
-			}
 
-			fmt.Printf(
-				"- %s: %v \n",
-				nagios.StateCRITICALLabel,
-				err,
-			)
+				fmt.Printf(
+					"- %s: Provided SANs entries match evaluated certificate\n",
+					nagios.StateOKLabel,
+				)
+			}
 
 		}
 	}


### PR DESCRIPTION
Changes made for GH-332 incorrectly moved the SANs list eval
results message out of the error handling path into the shared
path for both successful and failed evaluation.

This commit explicitly handles both scenarios which resolves
having a failure message shown for a successful evaluation and
provides an "eval success" message for that scenario.

- fixes GH-336
- refs GH-211