### PR TITLE
Use DNS Name if specified as hostVal for SNI

### DIFF
--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -117,15 +117,44 @@ func main() {
 		// Grab first IP Address from the resolved collection.
 		ipAddr := expandedHost.Expanded[0]
 
+		// Server Name Indication (SNI) support is used to request a specific
+		// certificate chain from a remote server.
+		//
+		// We use the value specified by the `server` flag to open a
+		// connection to the remote server. If available, we use the DNS Name
+		// value specified by the `dns-name` flag as our host value, otherwise
+		// we fallback to using the value specified by the `server` flag as
+		// our host value.
+		//
+		// For a service with only one certificate chain the host value is
+		// less important, but for a host with multiple certificate chains
+		// having the correct host value is crucial.
 		var hostVal string
 		switch {
-		case expandedHost.Resolved:
-			hostVal = expandedHost.Given
+
+		// We have a resolved IP Address and a sysadmin-specified DNS Name
+		// value to use for a SNI-enabled certificate retrieval attempt.
+		case expandedHost.Resolved && cfg.DNSName != "":
+			hostVal = cfg.DNSName
 			certChainSource = fmt.Sprintf(
-				"service running on %s (%s) at port %d",
-				hostVal,
+				"service running on %s (%s) at port %d using host value %q",
+				expandedHost.Given,
 				ipAddr,
 				cfg.Port,
+				hostVal,
+			)
+
+		// We have a resolved IP Address, but not a sysadmin-specified DNS
+		// Name value. We'll use the resolvable name/FQDN for a SNI-enabled
+		// certificate retrieval attempt.
+		case expandedHost.Resolved && cfg.DNSName == "":
+			hostVal = expandedHost.Given
+			certChainSource = fmt.Sprintf(
+				"service running on %s (%s) at port %d using host value %q",
+				expandedHost.Given,
+				ipAddr,
+				cfg.Port,
+				expandedHost.Given,
 			)
 		default:
 			certChainSource = fmt.Sprintf(
@@ -136,16 +165,15 @@ func main() {
 		}
 
 		log.Debug().
-			Str("host", hostVal).
+			Str("server", cfg.Server).
+			Str("dns_name", cfg.DNSName).
 			Str("ip_address", ipAddr).
+			Str("host_value", hostVal).
 			Int("port", cfg.Port).
 			Msg("Retrieving certificate chain")
 		var certFetchErr error
 		certChain, certFetchErr = netutils.GetCerts(
-			// NOTE: This is a potentially empty string depending on whether
-			// host pattern was a resolvable name/FQDN.
 			hostVal,
-
 			ipAddr,
 			cfg.Port,
 			cfg.Timeout(),


### PR DESCRIPTION
- use DNS Name if specified as the host value given
  to the remote service when retrieving certificates chain
- update doc comments explaining SNI support logic for
  cert retrieval
- explicitly report host value chosen for cert retrieval
- update debug message's structured log fields to explicitly
  note the chosen host value, DNS Name, Server values to
  better troubleshoot certificate chain retrieval

refs GH-343