### PR TITLE
Fix doc comment language

### DIFF
--- a/cmd/check_cert/annotations.go
+++ b/cmd/check_cert/annotations.go
@@ -90,7 +90,7 @@ func annotateError(logger zerolog.Logger, errs ...error) []error {
 
 		return annotatedErrors
 
-	// An empty collection was No errors were provided for evaluation
+	// No errors were provided for evaluation.
 	default:
 		return nil
 	}


### PR DESCRIPTION
It looks like I was merging two comments and didn't finish the thought.