### PR TITLE
lscert | Support parsing a URL via positional arg

### DIFF
--- a/internal/config/args.go
+++ b/internal/config/args.go
@@ -1,0 +1,58 @@
+// Copyright 2022 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package config
+
+import (
+	"flag"
+	"fmt"
+)
+
+// handlePositionalArgs handles any positional arguments remaining after flags
+// have been parsed. This behavior is controlled via the specified application
+// type as set by each cmd. Based on the application type, a specific set of
+// positional arguments are evaluated and potentially used to override default
+// values for defined flags.
+func (c *Config) handlePositionalArgs(appType AppType) error {
+
+	// fmt.Println("Evaluating positional arguments ...")
+	// fmt.Println("flag.Arg(0):", flag.Arg(0))
+	// fmt.Println("flag.Args():", flag.Args())
+
+	switch {
+	case appType.Plugin:
+
+		// placeholder
+
+	case appType.Inspecter:
+
+		// If flag.Arg(0) is non-empty, then flag parsing has already been
+		// applied and a positional argument is available for evaluation. We
+		// evaluate Arg(0) only if specific flag values have not already been
+		// provided.
+		if flag.Arg(0) != "" && c.Server == "" && c.Filename == "" {
+			err := c.parseServerValue(flag.Arg(0))
+			if err != nil {
+				return fmt.Errorf(
+					"error parsing server value: %w",
+					err,
+				)
+			}
+		}
+
+	case appType.Scanner:
+
+		// placeholder
+
+	}
+
+	// Shared positional argument handling for all application types goes
+	// here.
+
+	return nil
+
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -382,6 +382,10 @@ func New(appType AppType) (*Config, error) {
 		return nil, ErrVersionRequested
 	}
 
+	if err := config.handlePositionalArgs(appType); err != nil {
+		return nil, fmt.Errorf("failed to process positional arguments: %w", err)
+	}
+
 	if err := config.validate(appType); err != nil {
 		return nil, fmt.Errorf("configuration validation failed: %w", err)
 	}

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -1,0 +1,94 @@
+// Copyright 2022 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// parseServerValue evaluates a given string as a potential URL. If matched,
+// the URL is used to populate the Config.Server field. If the URL specifies a
+// port, the parsed port value is used to populate the Config.Port field. If
+// the given string is not parsed as a URL, the value is assigned directly to
+// the Config.Server field as-is.
+//
+// The caller is responsible for guarding against overwriting any values
+// already specified by flags.
+func (c *Config) parseServerValue(serverVal string) error {
+
+	// url.Parse() is very forgiving. A bare string value (e.g., "tacos") is
+	// treated as a relative URL or "path" value. In other words, a parse
+	// error is sufficient reason to abort further evaluation of the given
+	// server value.
+	u, err := url.Parse(serverVal)
+	if err != nil {
+		return fmt.Errorf(
+			"unable to parse %q as URL: %w",
+			serverVal,
+			err,
+		)
+	}
+
+	// We're populating the Config struct *before* validation is applied. As a
+	// result, we assign directly to the Config struct fields that are
+	// normally populated by specific flags.
+	switch {
+
+	// If the specified server value was successfully parsed as a URL with a
+	// hostname value we use that value to populate the Config.Server field
+	// and potentially the Config.Port field.
+	case u.Host != "":
+
+		switch {
+		case strings.Contains(u.Host, ":"):
+
+			// Remove any :port pattern from u.Host by splitting on
+			// ':' and throwing away the second portion.
+			uHost := strings.Split(u.Host, ":")
+
+			// Prevent invalid indexing
+			if len(uHost) > 0 {
+				c.Server = uHost[0]
+			}
+
+		default:
+
+			c.Server = u.Host
+		}
+
+		if u.Port() != "" {
+			uPort, err := strconv.Atoi(u.Port())
+			if err != nil {
+				return fmt.Errorf(
+					"failed to parse %q as port number: %w",
+					u.Port(),
+					err,
+				)
+			}
+
+			// NOTE: Config validation will apply bounds checks for
+			// integer port value (1:65535).
+			c.Port = uPort
+		}
+
+	// If the specified server value was successfully parsed as a URL without
+	// a hostname value (in which case the server value is treated as a
+	// relative URL) we use the specified server value as-is and assign
+	// directly to the Config.Server field.
+	default:
+
+		c.Server = serverVal
+
+	}
+
+	return nil
+
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -25,7 +25,9 @@ func (c Config) validate(appType AppType) error {
 		switch {
 		case c.Filename == "" && c.Server == "":
 			return fmt.Errorf(
-				"one of %q or %q flags must be specified",
+				"one of %q or %q flags must be specified"+
+					" or one of URL, FQDN or hostname provided"+
+					" via positional argument",
 				ServerFlagLong,
 				FilenameFlagLong,
 			)


### PR DESCRIPTION
Add support for accepting a URL via the first positional argument and using it to populate the Config.Server and Config.Port fields.

NOTE: The first positional argument is numbered 0 and accessible via flag.Arg(0).

If Config.Server is already set (presumably via the flag), then skip processing positional argument 0.

fixes GH-378