### PR TITLE
Update help text to reflect app-specific usage

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,9 +9,7 @@ package config
 
 import (
 	"errors"
-	"flag"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -338,20 +336,6 @@ type Config struct {
 
 	// Log is an embedded zerolog Logger initialized via config.New().
 	Log zerolog.Logger
-}
-
-// Usage is a custom override for the default Help text provided by the flag
-// package. Here we prepend some additional metadata to the existing output.
-func Usage() {
-
-	// Override default of stderr as destination for help output. This allows
-	// Nagios XI and similar monitoring systems to call plugins with the
-	// `--help` flag and have it display within the Admin web UI.
-	flag.CommandLine.SetOutput(os.Stdout)
-
-	fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
-	fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
-	flag.PrintDefaults()
 }
 
 // Version emits application name, version and repo location.


### PR DESCRIPTION
In short, add polish to the help text to better convey expected syntax
and intention of each tool.

- replace shared `config.Usage()` func with closure that
  makes use of a app-specific help/usage details
- explicitly reference "pattern" in the usage output for the `lscert`
  command
- emit application description just under usage syntax and before flag
  help text listing
- explicitly point the reader to the project README for full usage
  details (including emitting project URL)

Inspiration drawn from:

- `docker --help`
- `lxc  --help`
- https://github.com/inancgumus/effective-go/blob/de2dd6e07af9fdb65d425b38f2002a8fc99cc50e/ch05/cmd/hit/flags.go

refs GH-385