### PR TITLE
Apply Go 1.19 specific doc comments linting fixes

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,28 +1,25 @@
 /*
-
 This repo contains various tools used to monitor/validate certificates.
 
-PROJECT HOME
+# Project Home
 
-See our GitHub repo (https://github.com/atc0005/check-cert) for the latest
+See our [GitHub repo](https://github.com/atc0005/check-cert) for the latest
 code, to file an issue or submit improvements for review and potential
 inclusion into the project.
 
-PURPOSE
+# Purpose
 
 Monitor/validate certificates.
 
-FEATURES
+# Features
 
-• Nagios plugin for monitoring certificates of certificate-enabled services
+  - Nagios plugin for monitoring certificates of certificate-enabled services
+  - CLI tool for verifying certificates of certificate-enabled services or files
+  - CLI tool for generating summary of discovered certificates from given
+    hosts (single or IP Address ranges, hostnames or FQDNs) and ports
 
-• CLI tool for verifying certificates of certificate-enabled services or files
-
-• CLI tool for generating summary of discovered certificates from given hosts (single or IP Address ranges, hostnames or FQDNs) and ports
-
-USAGE
+# Usage
 
 See our main README for supported settings and examples.
-
 */
 package main


### PR DESCRIPTION
These changes are effectively a NOOP for earlier Go versions, but improve the formatting of rendered documentation.