### PR TITLE
Fix GitHub repo link syntax

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -3,9 +3,8 @@ This repo contains various tools used to monitor/validate certificates.
 
 # Project Home
 
-See our [GitHub repo](https://github.com/atc0005/check-cert) for the latest
-code, to file an issue or submit improvements for review and potential
-inclusion into the project.
+See our [GitHub repo] for the latest code, to file an issue or submit
+improvements for review and potential inclusion into the project.
 
 # Purpose
 
@@ -21,5 +20,7 @@ Monitor/validate certificates.
 # Usage
 
 See our main README for supported settings and examples.
+
+[GitHub repo]: https://github.com/atc0005/check-cert
 */
 package main


### PR DESCRIPTION
Go 1.19 requires link reference syntax, not the standard Markdown link syntax.