### PR TITLE
Clarify behavior of lscert positional argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,9 +607,8 @@ validation checks and any behavior changes at that time noted.
 
 ##### Positional Argument
 
-As of the v0.9.0 release the `lscert` tool accepts a single positional
-argument as an alternative to the `server` and `port` flags. This positional
-argument value can be any of:
+As of the v0.9.0 release the `lscert` tool accepts a URL pattern as a single
+positional argument. This positional argument value can be any of:
 
 - URL
 - resolvable name
@@ -639,6 +638,14 @@ Some valid examples:
 - `lscert https://www.google.com:443`
 - `lscert --log-level debug PATTERN`
 - `lscert --dns-name one.one.one.one 1.1.1.1`
+
+Aside from the required order of flags and positional argument noted above,
+there are additional requirements to be aware of:
+
+- if the `server` or `filename` flags are specified, the positional argument
+  is ignored
+- if the `port` flag is specified, its value will be ignored if a port is
+  provided in the given URL pattern positional argument
 
 #### `certsum`
 

--- a/internal/config/args.go
+++ b/internal/config/args.go
@@ -34,6 +34,10 @@ func (c *Config) handlePositionalArgs(appType AppType) error {
 		// applied and a positional argument is available for evaluation. We
 		// evaluate Arg(0) only if specific flag values have not already been
 		// provided.
+		//
+		// This prevents overwriting any values already specified by flags in
+		// order to provide the documented behavior for specified flags and
+		// the URL pattern positional argument.
 		if flag.Arg(0) != "" && c.Server == "" && c.Filename == "" {
 			err := c.parseServerValue(flag.Arg(0))
 			if err != nil {

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -30,11 +30,18 @@ func supportedValuesFlagHelpText(baseHelpText string, supportedValues []string) 
 // common to all application types.
 func (c *Config) handleFlagsConfig(appType AppType) {
 
-	// Application specific template used for generating lead-in usage/help
-	// text.
-	var usageTextHeaderTmpl string
+	var (
+		// Application specific template used for generating lead-in
+		// usage/help text.
+		usageTextHeaderTmpl string
 
-	var appDescription string
+		// Additional requirements for using positional arguments. May not
+		// apply to all application types.
+		positionalArgRequirements string
+
+		// A human readable description of the specific application.
+		appDescription string
+	)
 
 	// Flags specific to one application type or the other
 	switch {
@@ -100,6 +107,17 @@ func (c *Config) handleFlagsConfig(appType AppType) {
 		// https://stackoverflow.com/a/36787811/903870
 		// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html
 		usageTextHeaderTmpl = "%s\n\nUsage:  %s [flags] [pattern]\n\n%s\n\nFlags:\n"
+
+		positionalArgRequirements = fmt.Sprintf(
+			"\nPositional Argument (\"pattern\") Requirements:\n\n"+
+				"- if the %q or %q"+
+				" flags are specified, the URL pattern is ignored"+
+				"\n- if the %q flag is specified, its value will be"+
+				" ignored if a port is provided in the given URL pattern",
+			ServerFlagLong,
+			FilenameFlagLong,
+			PortFlagLong,
+		)
 
 		appDescription = "Used to generate a summary of certificate chain metadata and validation results for quick review."
 
@@ -217,6 +235,7 @@ func (c *Config) handleFlagsConfig(appType AppType) {
 
 		fmt.Fprintln(flag.CommandLine.Output(), headerText)
 		flag.PrintDefaults()
+		fmt.Fprintln(flag.CommandLine.Output(), positionalArgRequirements)
 		fmt.Fprintln(flag.CommandLine.Output(), footerText)
 	}
 


### PR DESCRIPTION
- update README to emphasize that the positional argument for the
  `lscert` tool is intended to be a URL pattern, but can be any of
  URL, resolvable name or IP Address
- update doc comments to clarify the requirements and behavior of the
  positional argument and the `server`, `port` and `filename` flags
- emit positional argument requirements for each of `lscert`,
  `check_cert` and `certsum` tools
  - at present only the `lscert` tool actually displays relevant
    output

fixes GH-384