### PR TITLE
Add missing cmd doc files

### DIFF
--- a/cmd/certsum/doc.go
+++ b/cmd/certsum/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// CLI app used to scan one or more given IP ranges or collection of name/FQDN
+// values in order to generate a report for discovered certificates. While
+// intended for mass discovery this tool may be used to scan as few as one
+// target.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/check-cert
+package main

--- a/cmd/check_cert/doc.go
+++ b/cmd/check_cert/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Nagios plugin used to monitor & validate certificate chains.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/check-cert
+package main

--- a/cmd/lscert/doc.go
+++ b/cmd/lscert/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// CLI app used to generate a summary of certificate chain metadata and
+// validation results.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/check-cert
+package main


### PR DESCRIPTION
Add "package" doc file to resolve revive package-comment linting error surfaced by recent linter update.