### PR TITLE
Add additional golangci-lint linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,9 +25,11 @@ linters:
     - gofmt
     - goimports
     - gosec
+    - govet
     - maligned
     - misspell
     - prealloc
     - revive
+    - staticcheck
     - stylecheck
     - unconvert


### PR DESCRIPTION
Enable additional linters that I already use within the atc0005/go-ci stable
images.

- govet
- staticcheck