### PR TITLE
Add govulncheck GitHub Actions Workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,51 @@
+# https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck
+# https://github.com/golang/vuln
+# https://github.com/atc0005/go-ci/issues/734
+
+name: Vulnerability Analysis
+
+# Run Workflow for Pull Requests (new, updated)
+# `synchronized` seems to equate to pushing new commits to a linked branch
+# (whether force-pushed or not)
+on:
+  pull_request:
+    types: [opened, synchronize]
+  schedule:
+    # ┌───────────── minute (0 - 59)
+    # │ ┌───────────── hour (0 - 23)
+    # │ │ ┌───────────── day of the month (1 - 31)
+    # │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    # │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    # │ │ │ │ │
+    # │ │ │ │ │
+    # │ │ │ │ │
+    # * * * * *
+    - cron: "19 2 * * 0"
+
+jobs:
+  govulncheck:
+    name: Run official Go vulnerability CLI tool
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: ghcr.io/atc0005/go-ci:go-ci-lint-only
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Run govulncheck against source code
+        run: |
+          govulncheck -json ./...
+
+      - name: Build using vendored dependencies
+        run: |
+          go build -v -mod=vendor ./cmd/check_cert
+          go build -v -mod=vendor ./cmd/lscert
+          go build -v -mod=vendor ./cmd/certsum
+
+      - name: Run govulncheck against compiled binaries
+        run: |
+          govulncheck -json ./check_cert
+          govulncheck -json ./lscert
+          govulncheck -json ./certsum


### PR DESCRIPTION
Add new `Vulnerability Analysis` GHAW that executes the experimental govulncheck CLI tool:

- against project source code
- against compiled project binaries

The workflow executes for new/updated Pull Requests and on a weekly schedule.

As with other GitHub Actions Workflows for this project, this Workflow relies upon the Docker images provided by the atc0005/go-ci project.

refs atc0005/go-ci#734