### PR TITLE
govulncheck: Disable binary build & scan step

### DIFF
--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -11,7 +11,11 @@ name: Vulnerability Analysis
 # `synchronized` seems to equate to pushing new commits to a linked branch
 # (whether force-pushed or not)
 on:
+  push:
+    branches: [master]
   pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
     types: [opened, synchronize]
   schedule:
     # ┌───────────── minute (0 - 59)
@@ -94,15 +98,3 @@ jobs:
       - name: Analyze source code
         run: |
           govulncheck -json ./...
-
-      - name: Build binaries
-        run: |
-          go build -v -mod=vendor ./cmd/check_cert
-          go build -v -mod=vendor ./cmd/lscert
-          go build -v -mod=vendor ./cmd/certsum
-
-      - name: Analyze binaries
-        run: |
-          govulncheck -json ./check_cert
-          govulncheck -json ./lscert
-          govulncheck -json ./certsum


### PR DESCRIPTION
Very light research seems to imply that binary scanning is unnecessary if you have access to the source code.

Disabling binary build & scan step for now until I learn differently.

Also, add "on push" event trigger to resolve GHAW linting warning related to the CodeQL analysis job.

refs atc0005/go-ci#734