### PR TITLE
Replace duplicate valid log levels entry

### DIFF
--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -177,11 +177,11 @@ func supportedValidationCheckResultKeywords() []string {
 	}
 }
 
-// supportedValidationCheckResultKeywords returns a list of valid log levels
-// supported by tools in this project.
+// supportedLogLevels returns a list of valid log levels supported by tools in
+// this project.
 func supportedLogLevels() []string {
 	return []string{
-		LogLevelDebug,
+		LogLevelDisabled,
 		LogLevelPanic,
 		LogLevelFatal,
 		LogLevelError,


### PR DESCRIPTION
Restore ability to use `disabled` as a valid log level per CLI flag.

fixes GH-427