### PR TITLE
Fix mispelling of Inspector app type

### DIFF
--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -27,7 +27,7 @@ import (
 func main() {
 
 	// Setup configuration by parsing user-provided flags.
-	cfg, cfgErr := config.New(config.AppType{Inspecter: true})
+	cfg, cfgErr := config.New(config.AppType{Inspector: true})
 	switch {
 	case errors.Is(cfgErr, config.ErrVersionRequested):
 		fmt.Println(config.Version())

--- a/internal/config/args.go
+++ b/internal/config/args.go
@@ -28,7 +28,7 @@ func (c *Config) handlePositionalArgs(appType AppType) error {
 
 		// placeholder
 
-	case appType.Inspecter:
+	case appType.Inspector:
 
 		// If flag.Arg(0) is non-empty, then flag parsing has already been
 		// applied and a positional argument is available for evaluation. We

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,12 +41,12 @@ type AppType struct {
 	// Plugin represents an application used as a Nagios plugin.
 	Plugin bool
 
-	// Inspecter represents an application used for one-off or isolated
+	// Inspector represents an application used for one-off or isolated
 	// checks. Unlike a Nagios plugin which is focused on specific attributes
-	// resulting in a severity-based outcome, an Inspecter application is
+	// resulting in a severity-based outcome, an Inspector application is
 	// intended for examining a small set of targets for
 	// informational/troubleshooting purposes.
-	Inspecter bool
+	Inspector bool
 }
 
 // multiValueStringFlag is a custom type that satisfies the flag.Value

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -224,7 +224,7 @@ const (
 
 const (
 	appTypePlugin    string = "plugin"
-	appTypeInspecter string = "inspecter"
+	appTypeInspector string = "inspector"
 	appTypeScanner   string = "scanner"
 )
 

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -94,7 +94,7 @@ func (c *Config) handleFlagsConfig(appType AppType) {
 			supportedValuesFlagHelpText(applyValidationResultsFlagHelp, supportedValidationCheckResultKeywords()),
 		)
 
-	case appType.Inspecter:
+	case appType.Inspector:
 
 		// Override the default Help output with a brief lead-in summary of
 		// the expected syntax and project version.

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -81,14 +81,14 @@ func (c *Config) setupLogging(appType AppType) error {
 	// troubleshooting. We can extend the logged fields as needed by each CLI
 	// application or Nagios plugin to cover unique details.
 	switch {
-	case appType.Inspecter:
+	case appType.Inspector:
 		// CLI app logging uses ConsoleWriter to generate human-friendly,
 		// colorized output to stdout.
 		consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout}
 		c.Log = zerolog.New(consoleWriter).With().Timestamp().Caller().
 			Str("version", Version()).
 			Str("logging_level", c.LoggingLevel).
-			Str("app_type", appTypeInspecter).
+			Str("app_type", appTypeInspector).
 			Str("filename", c.Filename).
 			Str("server", c.Server).
 			Int("port", c.Port).

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -19,7 +19,7 @@ import (
 func (c Config) validate(appType AppType) error {
 
 	switch {
-	case appType.Inspecter:
+	case appType.Inspector:
 		// User can specify one of filename or server, but not both (mostly in
 		// order to keep the logic simpler)
 		switch {


### PR DESCRIPTION
Replace `inspecter` with `inspector`.

I suspect that I was at least partially thinking of the Go idiom of naming interfaces with an `er` suffix when I came up with the app type.

refs atc0005/todo#49