### PR TITLE
Add host val when set & server is specified as IP

### DIFF
--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -147,6 +147,18 @@ func main() {
 				hostVal,
 			)
 
+		// We have a valid IP Address to use for opening the connection and a
+		// sysadmin-specified DNS Name value to use for a SNI-enabled
+		// certificate retrieval attempt.
+		case cfg.DNSName != "":
+			hostVal = cfg.DNSName
+			certChainSource = fmt.Sprintf(
+				"service running on %s at port %d using host value %q",
+				ipAddr,
+				cfg.Port,
+				hostVal,
+			)
+
 		// We have a resolved IP Address, but not a sysadmin-specified DNS
 		// Name value. We'll use the resolvable name/FQDN for a SNI-enabled
 		// certificate retrieval attempt.


### PR DESCRIPTION
Add equivalent fix for `lscert` tool to reflect equivalent changes made for the `check_cert` plugin.

This is needed to properly set the host value used when submitting SNI-compatible certificate chain request to the IP Address specified as the server value.

fixes GH-461