### PR TITLE
Add certificate perfdata metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Go-based tooling to check/verify certs (e.g., as part of a Nagios service check)
 - [Project home](#project-home)
 - [Overview](#overview)
   - [`check_certs`](#check_certs)
+    - [Performance Data](#performance-data)
   - [`lscert`](#lscert)
   - [`certsum`](#certsum)
 - [Features](#features)
@@ -135,6 +136,29 @@ For future releases, please review the release notes carefully for any
 breaking changes.
 
 ---
+
+#### Performance Data
+
+Initial support has been added for emitting Performance Data / Metrics, but
+refinement suggestions are welcome.
+
+Consult the tables below for the metrics implemented thus far.
+
+Please add to an existing
+[Discussion](https://github.com/atc0005/check-cert/discussions) thread
+(if applicable) or [open a new
+one](https://github.com/atc0005/check-cert/discussions/new) with any
+feedback that you may have. Thanks in advance!
+
+| Emitted Performance Data / Metric | Meaning                                                                                                                                                                                                                             |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `time`                            | Runtime for plugin                                                                                                                                                                                                                  |
+| `expires_leaf`                    | Days remaining before leaf (aka, "server") certificate expires. If multiple leaf certificates are present (invalid configuration), the one expiring soonest is reported.                                                            |
+| `expires_intermediate`            | Days remaining before the next to expire intermediate certificate expires.                                                                                                                                                          |
+| `certs_present_leaf`              | Number of leaf (aka, "server") certificates present in the chain.                                                                                                                                                                   |
+| `certs_present_intermediate`      | Number of intermediate certificates present in the chain.                                                                                                                                                                           |
+| `certs_present_root`              | Number of root certificates present in the chain.                                                                                                                                                                                   |
+| `certs_present_unknown`           | Number of certificates present in the chain with an unknown scope (i.e., the plugin cannot determine whether a leaf, intermediate or root). Please [report this scenario](https://github.com/atc0005/check-cert/issues/new/choose). |
 
 ### `lscert`
 

--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -380,6 +380,29 @@ func main() {
 		)
 	}
 
+	pd, perfDataErr := getPerfData(certChain, cfg.AgeCritical, cfg.AgeWarning)
+	if perfDataErr != nil {
+		log.Error().
+			Err(perfDataErr).
+			Msg("failed to generate performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(perfDataErr)
+
+		// TODO: Abort plugin execution with UNKNOWN status?
+	}
+
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		// TODO: Abort plugin execution with UNKNOWN status?
+	}
+
 	switch {
 	case validationResults.HasFailed():
 

--- a/cmd/check_cert/perfdata.go
+++ b/cmd/check_cert/perfdata.go
@@ -1,0 +1,106 @@
+// Copyright 2023 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strconv"
+
+	"github.com/atc0005/check-cert/internal/certs"
+	"github.com/atc0005/go-nagios"
+)
+
+// getPerfData generates performance data metrics from the given certificate
+// chain and certificate age thresholds. An error is returned if any are
+// encountered while gathering metrics or if an empty certificate chain is
+// provided.
+func getPerfData(certChain []*x509.Certificate, ageCritical int, ageWarning int) ([]nagios.PerformanceData, error) {
+	if len(certChain) == 0 {
+		return nil, fmt.Errorf(
+			"func getPerfData: unable to generate metrics: %w",
+			certs.ErrMissingValue,
+		)
+	}
+
+	var expiresLeaf int
+	oldestLeaf := certs.OldestLeafCert(certChain)
+	if daysToExpiration, err := certs.ExpiresInDays(oldestLeaf); err == nil {
+		expiresLeaf = daysToExpiration
+	}
+
+	var expiresIntermediate int
+	oldestIntermediate := certs.OldestIntermediateCert(certChain)
+	if daysToExpiration, err := certs.ExpiresInDays(oldestIntermediate); err == nil {
+		expiresIntermediate = daysToExpiration
+	}
+
+	var expiresRoot int
+	oldestRoot := certs.OldestRootCert(certChain)
+	if daysToExpiration, err := certs.ExpiresInDays(oldestRoot); err == nil {
+		expiresRoot = daysToExpiration
+	}
+
+	// TODO: Should we emit this metric?
+	_ = expiresRoot
+
+	certsPresentLeaf := strconv.Itoa(certs.NumLeafCerts(certChain))
+	certsPresentIntermediate := strconv.Itoa(certs.NumIntermediateCerts(certChain))
+	certsPresentRoot := strconv.Itoa(certs.NumRootCerts(certChain))
+	certsPresentUnknown := strconv.Itoa(certs.NumUnknownCerts(certChain))
+
+	pd := []nagios.PerformanceData{
+		{
+			Label:             "expires_leaf",
+			Value:             fmt.Sprintf("%d", expiresLeaf),
+			UnitOfMeasurement: "d",
+			Warn:              fmt.Sprintf("%d", ageWarning),
+			Crit:              fmt.Sprintf("%d", ageCritical),
+		},
+		{
+			Label:             "expires_intermediate",
+			Value:             fmt.Sprintf("%d", expiresIntermediate),
+			UnitOfMeasurement: "d",
+			Warn:              fmt.Sprintf("%d", ageWarning),
+			Crit:              fmt.Sprintf("%d", ageCritical),
+		},
+
+		// TODO: Should we even track this? If we report 0 as a default value
+		// when the cert is not found, how will that differ from when the cert
+		// is actually present and expired?
+		//
+		//
+		// NOTE: Current thinking is that I should not include root cert
+		// expiration perfdata; root cert should ideally not be in the chain
+		// per current best practice(s).
+		// {
+		// 	Label:             "expires_root",
+		// 	Value:             fmt.Sprintf("%d", expiresRoot),
+		// 	UnitOfMeasurement: "d",
+		// },
+		{
+			Label: "certs_present_leaf",
+			Value: certsPresentLeaf,
+		},
+		{
+			Label: "certs_present_intermediate",
+			Value: certsPresentIntermediate,
+		},
+		{
+			Label: "certs_present_root",
+			Value: certsPresentRoot,
+		},
+		{
+			Label: "certs_present_unknown",
+			Value: certsPresentUnknown,
+		},
+	}
+
+	return pd, nil
+
+}


### PR DESCRIPTION
## Overview

Add performance data metrics to track upcoming expirations and total certificate types (scopes) in the chain:

- `expires_leaf`
- `expires_intermediate`
- `certs_present_leaf`
- `certs_present_intermediate`
- `certs_present_root`
- `certs_present_unknown`

As part of providing these performance data metrics various helper functions were added:

- `certs.NumLeafCerts`
- `certs.NumIntermediateCerts`
- `certs.NumRootCerts`
- `certs.NumUnknownCerts`
- `certs.LeafCerts`
- `certs.IntermediateCerts`
- `certs.RootCerts`
- `certs.OldestLeafCert`
- `certs.OldestIntermediateCert`
- `certs.OldestRootCert`
- `certs.ExpiresInDays`

The README file has been updated to list the purpose of each performance data metric.

As of this commit, failure to collect performance data is emitted as an error message and recorded in the plugin's error collection (for display in `LongServiceOutput`). Future work is scheduled to revisit this choice and audit exit states as a whole to determine if more appropriate exit states should be used.

## References

- fixes GH-445
- GH-464