### PR TITLE
Update checksum generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -402,14 +402,16 @@ packages:
 
 	@echo "  - DEB package checksum file"
 	@set -e ;\
-		DEB_PKG=$$(find $(OUTPUTDIR) -name "*.deb" -printf '%P' | head -n 1); \
-		cd $(OUTPUTDIR); \
-		$(CHECKSUMCMD) $${DEB_PKG} > $${DEB_PKG}.sha256 ;\
+		for file in $$(find $(ROOTPATH) -name "*.deb" -printf '%P'); do \
+			cd $(ROOTPATH); \
+			$(CHECKSUMCMD) $${file} > $${file}.sha256 ; \
+		done
 
 	@echo "  - RPM package checksum file"
 	@set -e ;\
-		for file in $$(find $(OUTPUTDIR) -name "*.rpm" -printf '%P'); do \
-			cd $(OUTPUTDIR) && $(CHECKSUMCMD) $${file} > $${file}.sha256 ; \
+		for file in $$(find $(ROOTPATH) -name "*.rpm" -printf '%P'); do \
+			cd $(ROOTPATH); \
+			$(CHECKSUMCMD) $${file} > $${file}.sha256 ; \
 		done
 
 	@echo


### PR DESCRIPTION
- generate checksum files for *all* deb packages
- formatting changes for rpm checksum file generation (NOOP)
- switch from unqualified path in `OUTPUTDIR` Makefile variable to fully-qualified `ROOTPATH` variable
  - NOTE: More of these changes pending

refs GH-471