### PR TITLE
Add version details to Windows executables

### DIFF
--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -21,4 +21,8 @@ jobs:
 
   lint_and_build_using_makefile:
     name: Makefile
+    with:
+      # Indicate to imported workflow that the gogeninstall Makefile recipe is
+      # needed.
+      gogeninstall: true
     uses: atc0005/shared-project-resources/.github/workflows/lint-and-build-using-make.yml@master

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@
 # Ignore Visual Studio Code workspace-level settings
 /.vscode
 
+# Ignore go generate produced Windows executable resource files
+*.syso
+
 # Ignore local "scratch" directory of temporary files
 scratch/
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ OUTPUTDIR 				:= release_assets
 
 ROOT_PATH				:= $(CURDIR)/$(OUTPUTDIR)
 
+PROJECT_DIR				:= $(CURDIR)
+
 # https://gist.github.com/TheHippo/7e4d9ec4b7ed4c0d7a39839e6800cc16
 VERSION 				:= $(shell git describe --always --long --dirty)
 
@@ -170,6 +172,7 @@ goclean:
 	@rm -vf $(wildcard $(ROOT_PATH)/*.deb)
 	@rm -vf $(wildcard $(ROOT_PATH)/*.deb.sha256)
 	@rm -vf $(wildcard $(ROOT_PATH)/*-links.txt)
+	@rm -vf $(wildcard $(PROJECT_DIR)/cmd/*/*.syso)
 
 	@echo "Removing any existing quick build release assets"
 	@for target in $(WHAT); do \
@@ -248,8 +251,12 @@ windows-x86-build:
 
 	@for target in $(WHAT); do \
 		mkdir -p $(ROOT_PATH)/$$target && \
+		echo "  running go generate for $$target 386 binary ..." && \
+		cd $(PROJECT_DIR)/cmd/$$target && \
+		env GOOS=windows GOARCH=386 go generate && \
+		cd $(PROJECT_DIR) && \
 		echo "  building $$target 386 binary" && \
-		env GOOS=windows GOARCH=386 $(BUILDCMD) -o $(ROOT_PATH)/$$target/$$target-windows-386.exe ${PWD}/cmd/$$target; \
+		env GOOS=windows GOARCH=386 $(BUILDCMD) -o $(ROOT_PATH)/$$target/$$target-windows-386.exe $(PROJECT_DIR)/cmd/$$target; \
 	done
 
 	@echo "Completed build tasks for windows x86"
@@ -300,8 +307,12 @@ windows-x64-build:
 
 	@for target in $(WHAT); do \
 		mkdir -p $(ROOT_PATH)/$$target && \
+		echo "  running go generate for $$target amd64 binary ..." && \
+		cd $(PROJECT_DIR)/cmd/$$target && \
+		env GOOS=windows GOARCH=amd64 go generate && \
+		cd $(PROJECT_DIR) && \
 		echo "  building $$target amd64 binary" && \
-		env GOOS=windows GOARCH=amd64 $(BUILDCMD) -o $(ROOT_PATH)/$$target/$$target-windows-amd64.exe ${PWD}/cmd/$$target; \
+		env GOOS=windows GOARCH=amd64 $(BUILDCMD) -o $(ROOT_PATH)/$$target/$$target-windows-amd64.exe $(PROJECT_DIR)/cmd/$$target; \
 	done
 
 	@echo "Completed build tasks for windows x64"

--- a/cmd/certsum/main.go
+++ b/cmd/certsum/main.go
@@ -5,6 +5,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root for
 // full license information.
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 package main
 
 import (

--- a/cmd/certsum/winres/winres.json
+++ b/cmd/certsum/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "CLI app used to scan/discover certificates.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-cert project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "CLI app used to scan/discover certificates.",
+            "FileVersion": "",
+            "InternalName": "certsum",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-cert",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -5,6 +5,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root for
 // full license information.
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 package main
 
 import (

--- a/cmd/check_cert/winres/winres.json
+++ b/cmd/check_cert/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor & validate certificate chains.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-cert project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor & validate certificate chains.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-cert",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -5,6 +5,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root for
 // full license information.
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 package main
 
 import (

--- a/cmd/lscert/winres/winres.json
+++ b/cmd/lscert/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "CLI app used to generate a summary of certificate chain metadata and validation results.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-cert project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "CLI app used to generate a summary of certificate chain metadata and validation results.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-cert",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/dependabot/tools/go.mod
+++ b/dependabot/tools/go.mod
@@ -1,0 +1,16 @@
+module github.com/atc0005/check-cert/dependabot/tools
+
+go 1.19
+
+// go-winres - used by go generate build step
+require github.com/tc-hib/go-winres v0.3.1
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/tc-hib/winres v0.1.6 // indirect
+	github.com/urfave/cli/v2 v2.23.7 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+	golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb // indirect
+)

--- a/dependabot/tools/tools.go
+++ b/dependabot/tools/tools.go
@@ -1,0 +1,13 @@
+// +build tools
+
+package tools
+
+// Manage tool dependencies via go.mod.
+//
+// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+// https://github.com/golang/go/issues/25922
+//
+// nolint
+import (
+	_ "github.com/tc-hib/go-winres"
+)


### PR DESCRIPTION
Use tc-hib/go-winres and JSON config files to embed metadata (e.g., version, description) into Windows executables via `go generate`.

Related changes:

- add winres.json files to provide metadata to be embedded into generated Windows executables
- add `go generate` directives to main.go files
- add dependabot/tools entry for tc-hib/go-winres
- add .gitignore entry for .syso files created by tc-hib/go-winres
- Update Makefile build recipes to run `go generate` for Windows builds
- Update GHAW to indicate to shared/imported workflow that
  gogeninstall Makefile recipe is needed for builds

fixes GH-473