### PR TITLE
Fix windows-x64 binary links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ windows-x64-links:
 
 	@set -e; for target in $(WHAT); do \
 		echo "  generating $$target download links" && \
-		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-windows-amd64.exe" >> $(ALL_DOWNLOAD_LINKS_FILE) && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-windows-amd64.exe.xz" >> $(ALL_DOWNLOAD_LINKS_FILE) && \
 		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-windows-amd64.exe.xz.sha256" >> $(ALL_DOWNLOAD_LINKS_FILE); \
 	done
 


### PR DESCRIPTION
Download links for windows x64 binaries were generated with incorrect suffix.