### PR TITLE
Update package filename generation patterns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,12 @@ PROJECT_DIR				:= $(CURDIR)
 # https://gist.github.com/TheHippo/7e4d9ec4b7ed4c0d7a39839e6800cc16
 VERSION 				:= $(shell git describe --always --long --dirty)
 
+DEB_X64_STABLE_PKG_FILE	:= $(PROJECT_NAME)-$(VERSION)_amd64.deb
+RPM_X64_STABLE_PKG_FILE	:= $(PROJECT_NAME)-$(VERSION).x86_64.rpm
+
+DEB_X64_DEV_PKG_FILE	:= $(PROJECT_NAME)-dev-$(VERSION)_amd64.deb
+RPM_X64_DEV_PKG_FILE	:= $(PROJECT_NAME)-dev-$(VERSION).x86_64.rpm
+
 # Used when generating download URLs when building assets for public release.
 # If the current commit doesn't match an existing tag an error is emitted. We
 # toss that error and use a placeholder value.
@@ -556,12 +562,12 @@ packages-stable: linux-x64-build
 	@echo
 	@echo "  - stable DEB package ..."
 	@cd $(PROJECT_DIR)/packages/stable && \
-		nfpm package --config nfpm.yaml --packager deb --target $(ASSETS_PATH)/packages/stable
+		nfpm package --config nfpm.yaml --packager deb --target $(ASSETS_PATH)/packages/stable/$(DEB_X64_STABLE_PKG_FILE)
 
 	@echo
 	@echo "  - stable RPM package ..."
 	@cd $(PROJECT_DIR)/packages/stable && \
-		nfpm package --config nfpm.yaml --packager rpm --target $(ASSETS_PATH)/packages/stable
+		nfpm package --config nfpm.yaml --packager rpm --target $(ASSETS_PATH)/packages/stable/$(RPM_X64_STABLE_PKG_FILE)
 
 	@echo
 	@echo "Generating checksum files ..."
@@ -595,12 +601,12 @@ packages-dev: linux-x64-dev-build
 	@echo
 	@echo "  - dev DEB package ..."
 	@cd $(PROJECT_DIR)/packages/dev && \
-		nfpm package --config nfpm.yaml --packager deb --target $(ASSETS_PATH)/packages/dev
+		nfpm package --config nfpm.yaml --packager deb --target $(ASSETS_PATH)/packages/dev/$(DEB_X64_DEV_PKG_FILE)
 
 	@echo
 	@echo "  - dev RPM package ..."
 	@cd $(PROJECT_DIR)/packages/dev && \
-		nfpm package --config nfpm.yaml --packager rpm --target $(ASSETS_PATH)/packages/dev
+		nfpm package --config nfpm.yaml --packager rpm --target $(ASSETS_PATH)/packages/dev/$(RPM_X64_DEV_PKG_FILE)
 
 	@echo
 	@echo "Generating checksum files ..."
@@ -637,31 +643,31 @@ package-links:
 	@if [ -d $(ASSETS_PATH)/packages/dev ]; then \
 		cd $(ASSETS_PATH)/packages/dev && \
 		for file in $$(find . -name "*.deb" -printf '%P'); do \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
 		done; \
 	fi
 	@if [ -d $(ASSETS_PATH)/packages/dev ]; then \
 		cd $(ASSETS_PATH)/packages/dev && \
 		for file in $$(find . -name "*.deb.sha256" -printf '%P'); do \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
 		done; \
 	fi
 
 	@if [ -d $(ASSETS_PATH)/packages/stable ]; then \
 		cd $(ASSETS_PATH)/packages/stable && \
 		for file in $$(find . -name "*.deb" -printf '%P'); do \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
 		done; \
 	fi
 
 	@if [ -d $(ASSETS_PATH)/packages/stable ]; then \
 		cd $(ASSETS_PATH)/packages/stable && \
 		for file in $$(find . -name "*.deb.sha256" -printf '%P'); do \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
 		done; \
 	fi
 
@@ -669,31 +675,31 @@ package-links:
 	@if [ -d $(ASSETS_PATH)/packages/dev ]; then \
 		cd $(ASSETS_PATH)/packages/dev && \
 		for file in $$(find . -name "*.rpm" -printf '%P'); do \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
 		done; \
 	fi
 	@if [ -d $(ASSETS_PATH)/packages/dev ]; then \
 		cd $(ASSETS_PATH)/packages/dev && \
 		for file in $$(find . -name "*.rpm.sha256" -printf '%P'); do \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
 		done; \
 	fi
 
 	@if [ -d $(ASSETS_PATH)/packages/stable ]; then \
 		cd $(ASSETS_PATH)/packages/stable && \
 		for file in $$(find . -name "*.rpm" -printf '%P'); do \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
 		done; \
 	fi
 
 	@if [ -d $(ASSETS_PATH)/packages/stable ]; then \
 		cd $(ASSETS_PATH)/packages/stable && \
 		for file in $$(find . -name "*.rpm.sha256" -printf '%P'); do \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
-			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file/\~/\.}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
 		done; \
 	fi
 


### PR DESCRIPTION
## Overview

In short, this commit changes the Makefile logic to move from generating filenames like these:

```
check-cert-0.11.0~1-g6bc2774.x86_64.rpm
check-cert-0.11.0~1-g6bc2774.x86_64.rpm.sha256
check-cert_0.11.0~1-g6bc2774_amd64.deb
check-cert_0.11.0~1-g6bc2774_amd64.deb.sha256
```

to names like:

```
check-cert-0.11.0-1-g6bc2774.x86_64.rpm
check-cert-0.11.0-1-g6bc2774.x86_64.rpm.sha256
check-cert_0.11.0-1-g6bc2774_amd64.deb
check-cert_0.11.0-1-g6bc2774_amd64.deb.sha256
```

If the builds are performed with uncommitted local changes the "dirty" string is included to make that clear.

Example:

```
check-cert-dev-v0.11.0-2-g803b81f-dirty.x86_64.rpm
check-cert-dev-v0.11.0-2-g803b81f-dirty.x86_64.rpm.sha256
check-cert-dev-v0.11.0-2-g803b81f-dirty_amd64.deb
check-cert-dev-v0.11.0-2-g803b81f-dirty_amd64.deb.sha256
```

This is achieved by using templated package names instead of allowing nfpm to auto-generate names based on version control details.

This commit also removes the incomplete workaround applied previously in commit 6bc27746974bc7eeee0a5af782e8415f140a8460 to substitute the tilde character with a dot.

- fixes GH-496
- fixes GH-495