### PR TITLE
Update versioned build image source syntax

### DIFF
--- a/dependabot/docker/builds/Dockerfile
+++ b/dependabot/docker/builds/Dockerfile
@@ -13,4 +13,4 @@
 
 # https://github.com/atc0005/go-ci/releases
 # https://github.com/atc0005/go-ci/pkgs/container/go-ci
-FROM ghcr.io/atc0005/go-ci:go-ci-oldstable-build-v0.8.0-2-g87114607
+FROM ghcr.io/atc0005/go-ci:go-ci-oldstable-build-v0.8.0


### PR DESCRIPTION
The dependabot/docker/builds/Dockerfile was set to use this image:

- go-ci-oldstable-build-v0.8.0-2-g87114607

and earlier an updated image was released, but Dependabot refused to recognize it as an update:

- go-ci-oldstable-build-v0.8.1-0-ga96dbbdb

I've released alternate tags without the "long" git tag details closer to what Dependabot parses for other Dockerfiles that it monitors.

Updating the Dockerfile to that simpler version tag as a troubleshooting step.