### PR TITLE
Replace gogeninstall recipe with depsinstall

### DIFF
--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -21,8 +21,4 @@ jobs:
 
   lint_and_build_using_makefile:
     name: Makefile
-    with:
-      # Indicate to imported workflow that the gogeninstall Makefile recipe is
-      # needed.
-      gogeninstall: true
     uses: atc0005/shared-project-resources/.github/workflows/lint-and-build-using-make.yml@master

--- a/Makefile
+++ b/Makefile
@@ -202,24 +202,15 @@ gitclean:
 ## pristine: run goclean and gitclean to remove local changes
 pristine: goclean gitclean
 
-.PHONY: gogeninstall
-## gogeninstall: install tools used by go generate
-gogeninstall:
-	@echo "Installing current version of go generate dependencies"
+.PHONY: depsinstall
+## depsinstall: install or update common build dependencies
+depsinstall:
+	@echo "Installing current version of build dependencies"
 
 	@export PATH="${PATH}:$(go env GOPATH)/bin"
 
 	@echo "Installing latest go-winres version ..."
 	go install github.com/tc-hib/go-winres@latest
-
-	@echo "Finished installing or updating go generate dependencies"
-
-.PHONY: depsinstall
-## depsinstall: install or update common build dependencies
-depsinstall: gogeninstall
-	@echo "Installing current version of build dependencies"
-
-	@export PATH="${PATH}:$(go env GOPATH)/bin"
 
 	@echo "Installing latest nFPM version ..."
 	go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest


### PR DESCRIPTION
The distinction between "go generate" and general build dependencies isn't important enough to maintain separate Makefile recipes.

refs https://github.com/atc0005/shared-project-resources/issues/71