### PR TITLE
Add TODO to open upstream RFE re unexpected error

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -77,9 +77,17 @@ var (
 	// ErrX509CertReliesOnCommonName mirrors the unexported error string
 	// emitted by the HostnameError.Error() method from the x509 package.
 	//
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.20.1:src/crypto/x509/verify.go;l=104
+	//
 	// This error string is emitted when a certificate is missing Subject
 	// Alternate Names (SANs) AND a specified hostname matches the Common Name
 	// field.
+	//
+	// TODO: Open RFE in Go project asking that this be made an exportable
+	// error value so that we can drop this hard-coded version (which is bound
+	// to become a problem at some point).
+	// https://github.com/atc0005/check-cert/issues/520
+	//
 	ErrX509CertReliesOnCommonName = errors.New("x509: certificate relies on legacy Common Name field, use SANs instead")
 
 	// ErrNoCertValidationResults indicates that the cert chain validation


### PR DESCRIPTION
The `ErrX509CertReliesOnCommonName` sentinel error is used by this project to aid in detecting this specific error scenario. While performing a string match for this error works at present, it feels brittle and subject to break in the future if the error text should change.

By opening a RFE/proposal in the upstream Go project, we may gain a supported/stable approach for matching the error in the future.

refs GH-520