### PR TITLE
Fix hostname validation opt-out behavior

### DIFF
--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -57,10 +57,10 @@ func (c Config) Hosts() []netutils.HostPattern {
 	return []netutils.HostPattern{}
 }
 
-// ApplyCertHostnameValidationResults indicates whether hostname certificate
-// hostname validation check results should be applied when performing final
-// plugin state evaluation. Precedence is given for explicit request to ignore
-// this validation result.
+// ApplyCertHostnameValidationResults indicates whether certificate hostname
+// validation check results should be applied when performing final plugin
+// state evaluation. Precedence is given for explicit request to ignore this
+// validation result.
 func (c Config) ApplyCertHostnameValidationResults() bool {
 
 	ignoreRequested := textutils.InList(


### PR DESCRIPTION
- update handling of `ErrX509CertReliesOnCommonName` error condition to respect explicit request from sysadmin to ignore validation results
- helper func doc comments cleanup
- clarify certs.ValidateHostname behavior
  - emphasize that explicit request from sysadmin to ignore validation results is respected
  - note why check results are ignored when the SANs list is found to be empty (when requested)

fixes GH-505