### PR TITLE
Use certs.CertChainValidationOptions struct

### DIFF
--- a/cmd/certsum/summary.go
+++ b/cmd/certsum/summary.go
@@ -94,12 +94,17 @@ func printSummaryHighLevel(
 			name = strings.Join(certChain.Certs[0].DNSNames, ", ")
 		}
 
+		// Explicitly enable expiration validation.
+		validationOptions := certs.CertChainValidationOptions{
+			IgnoreValidationResultExpiration: false,
+		}
+
 		validationResults := certs.ValidateExpiration(
 			certChain.Certs,
 			ageCritical,
 			ageWarning,
 			true,
-			false,
+			validationOptions,
 		)
 
 		switch {

--- a/cmd/check_cert/validate.go
+++ b/cmd/check_cert/validate.go
@@ -27,9 +27,11 @@ func runValidationChecks(cfg *config.Config, certChain []*x509.Certificate, log 
 		certChain,
 		cfg.Server,
 		cfg.DNSName,
-		cfg.ApplyCertHostnameValidationResults(),
-		cfg.IgnoreHostnameVerificationFailureIfEmptySANsList,
 		config.IgnoreHostnameVerificationFailureIfEmptySANsListFlag,
+		certs.CertChainValidationOptions{
+			IgnoreHostnameVerificationFailureIfEmptySANsList: cfg.IgnoreHostnameVerificationFailureIfEmptySANsList,
+			IgnoreValidationResultSANs:                       !cfg.ApplyCertHostnameValidationResults(),
+		},
 	)
 	validationResults.Add(hostnameValidationResult)
 
@@ -50,9 +52,11 @@ func runValidationChecks(cfg *config.Config, certChain []*x509.Certificate, log 
 
 	sansValidationResult := certs.ValidateSANsList(
 		certChain,
-		cfg.ApplyCertSANsListValidationResults(),
 		cfg.DNSName,
 		cfg.SANsEntries,
+		certs.CertChainValidationOptions{
+			IgnoreValidationResultSANs: !cfg.ApplyCertSANsListValidationResults(),
+		},
 	)
 	validationResults.Add(sansValidationResult)
 
@@ -80,8 +84,10 @@ func runValidationChecks(cfg *config.Config, certChain []*x509.Certificate, log 
 		certChain,
 		cfg.AgeCritical,
 		cfg.AgeWarning,
-		cfg.ApplyCertExpirationValidationResults(),
 		cfg.VerboseOutput,
+		certs.CertChainValidationOptions{
+			IgnoreValidationResultExpiration: !cfg.ApplyCertExpirationValidationResults(),
+		},
 	)
 
 	validationResults.Add(expirationValidationResult)

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -234,9 +234,11 @@ func main() {
 		certChain,
 		cfg.Server,
 		cfg.DNSName,
-		cfg.ApplyCertHostnameValidationResults(),
-		cfg.IgnoreHostnameVerificationFailureIfEmptySANsList,
 		config.IgnoreHostnameVerificationFailureIfEmptySANsListFlag,
+		certs.CertChainValidationOptions{
+			IgnoreHostnameVerificationFailureIfEmptySANsList: cfg.IgnoreHostnameVerificationFailureIfEmptySANsList,
+			IgnoreValidationResultHostname:                   !cfg.ApplyCertHostnameValidationResults(),
+		},
 	)
 
 	switch {
@@ -276,9 +278,11 @@ func main() {
 
 	sansValidationResult := certs.ValidateSANsList(
 		certChain,
-		cfg.ApplyCertSANsListValidationResults(),
 		cfg.DNSName,
 		cfg.SANsEntries,
+		certs.CertChainValidationOptions{
+			IgnoreValidationResultSANs: !cfg.ApplyCertSANsListValidationResults(),
+		},
 	)
 	switch {
 	case sansValidationResult.IsFailed():
@@ -322,8 +326,10 @@ func main() {
 		certChain,
 		cfg.AgeCritical,
 		cfg.AgeWarning,
-		cfg.ApplyCertExpirationValidationResults(),
 		cfg.VerboseOutput,
+		certs.CertChainValidationOptions{
+			IgnoreValidationResultExpiration: !cfg.ApplyCertExpirationValidationResults(),
+		},
 	)
 	switch {
 	case expirationValidationResult.IsFailed():

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -105,6 +105,46 @@ type ServiceStater interface {
 	IsOKState() bool
 }
 
+// CertChainValidationOptions is a collection of validation options shared by
+// all validation functions for types implementing the
+// CertChainValidationResult interface.
+//
+// Not all options are used by each validation function.
+type CertChainValidationOptions struct {
+
+	// IgnoreHostnameVerificationFailureIfEmptySANsList tracks whether a
+	// request was made to ignore validation check results for the hostname
+	// when the leaf certificate's Subject Alternate Names (SANs) list is
+	// found to be empty.
+	IgnoreHostnameVerificationFailureIfEmptySANsList bool
+
+	// IgnoreValidationResultExpiration tracks whether a request was made to
+	// ignore validation check results for certificate expiration. This is a
+	// broad/blanket request that ignores expiration validation issues for ALL
+	// certificates in a chain, not just the leaf/server certificate.
+	IgnoreValidationResultExpiration bool
+
+	// IgnoreValidationResultHostname tracks whether a request was made to
+	// ignore validation check results from verifying a given hostname against
+	// the leaf certificate in a certificate chain.
+	IgnoreValidationResultHostname bool
+
+	// IgnoreValidationResultSANs tracks whether a request was made to ignore
+	// validation check results result from performing a Subject Alternate
+	// Names (SANs) validation against a leaf certificate in a chain.
+	IgnoreValidationResultSANs bool
+
+	// IgnoreExpiredIntermediateCertificates tracks whether a request was made
+	// to ignore validation check results for certificate expiration against
+	// intermediate certificates in a certificate chain.
+	IgnoreExpiredIntermediateCertificates bool
+
+	// IgnoreExpiredRootCertificates tracks whether a request was made to
+	// ignore validation check results for certificate expiration against root
+	// certificates in a certificate chain.
+	IgnoreExpiredRootCertificates bool
+}
+
 // DiscoveredCertChain represents the certificate chain found on a specific
 // host along with that host's IP/Name and port.
 type DiscoveredCertChain struct {


### PR DESCRIPTION
Add and use `certs.CertChainValidationOptions` struct to specify validation settings for use by `certs.Validate*` funcs. This provides a common Options struct to help prevent growing the parameters list excessively (e.g., as additional validation support is added in the future).

Client code for the `certs.Validate*` funcs has been updated to reflect these changes.

This set of changes is being made in preparation for supporting ignoring of expired intermediate and root certs.

refs GH-397