### PR TITLE
Fix disabling of hostname validation

### DIFF
--- a/cmd/check_cert/validate.go
+++ b/cmd/check_cert/validate.go
@@ -30,7 +30,7 @@ func runValidationChecks(cfg *config.Config, certChain []*x509.Certificate, log 
 		config.IgnoreHostnameVerificationFailureIfEmptySANsListFlag,
 		certs.CertChainValidationOptions{
 			IgnoreHostnameVerificationFailureIfEmptySANsList: cfg.IgnoreHostnameVerificationFailureIfEmptySANsList,
-			IgnoreValidationResultSANs:                       !cfg.ApplyCertHostnameValidationResults(),
+			IgnoreValidationResultHostname:                   !cfg.ApplyCertHostnameValidationResults(),
 		},
 	)
 	validationResults.Add(hostnameValidationResult)


### PR DESCRIPTION
## Changes

- The wrong `CertChainValidationOptions` field was set when requesting hostname validation
  - the `IgnoreValidationResultSANs` field was set instead of the `IgnoreValidationResultHostname` as intended
- Explicitly log `CertChainValidationOptions` values
  - log field values prior to each validation check to aid with future troubleshooting

## References

- refs GH-525