### PR TITLE
Permit negative expiration perfdata values

### DIFF
--- a/cmd/check_cert/perfdata.go
+++ b/cmd/check_cert/perfdata.go
@@ -52,7 +52,6 @@ func getPerfData(certChain []*x509.Certificate, ageCritical int, ageWarning int)
 			UnitOfMeasurement: "d",
 			Warn:              fmt.Sprintf("%d", ageWarning),
 			Crit:              fmt.Sprintf("%d", ageCritical),
-			Min:               "0",
 		},
 		{
 			Label:             "expires_intermediate",
@@ -60,7 +59,6 @@ func getPerfData(certChain []*x509.Certificate, ageCritical int, ageWarning int)
 			UnitOfMeasurement: "d",
 			Warn:              fmt.Sprintf("%d", ageWarning),
 			Crit:              fmt.Sprintf("%d", ageCritical),
-			Min:               "0",
 		},
 		{
 			Label: "certs_present_leaf",

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -614,28 +614,6 @@ func OldestRootCert(certChain []*x509.Certificate) *x509.Certificate {
 // is returned indicating how many days the certificate is past expiration.
 //
 // An error is returned if the pointer to the given certificate is nil.
-// func ExpiresInDays(cert *x509.Certificate) (int, error) {
-// 	if cert == nil {
-// 		return 0, fmt.Errorf(
-// 			"func ExpiresInDays: unable to determine expiration: %w",
-// 			ErrMissingValue,
-// 		)
-// 	}
-//
-// 	timeRemaining := time.Until(cert.NotAfter).Hours()
-//
-// 	// Toss remainder so that we only get the whole number of days
-// 	daysRemaining := int(math.Trunc(timeRemaining / 24))
-//
-// 	return daysRemaining, nil
-// }
-
-// ExpiresInDays evaluates the given certificate and returns the number of
-// days until the certificate expires. Zero is returned if the certificate is
-// expired or if the remaining certificate lifetime is shorter than one full
-// day.
-//
-// An error is returned if the pointer to the given certificate is nil.
 func ExpiresInDays(cert *x509.Certificate) (int, error) {
 	if cert == nil {
 		return 0, fmt.Errorf(
@@ -648,11 +626,6 @@ func ExpiresInDays(cert *x509.Certificate) (int, error) {
 
 	// Toss remainder so that we only get the whole number of days
 	daysRemaining := int(math.Trunc(timeRemaining / 24))
-
-	// Zero is our baseline for now.
-	if daysRemaining < 0 {
-		daysRemaining = 0
-	}
 
 	return daysRemaining, nil
 }


### PR DESCRIPTION
- remove the limiter that disallowed negative expiration value (returning 0 as the baseline)
- remove the `min` perfdata field value of 0 indicating that this was as low as the metric value could go

fixes GH-529