### PR TITLE
Update SELinux context handling in RPM packages

### DIFF
--- a/packages/dev/nfpm.yaml
+++ b/packages/dev/nfpm.yaml
@@ -69,6 +69,10 @@ contents:
 
 overrides:
   rpm:
+    depends:
+      # Provides selinuxenabled tool.
+      # Installed by default even via the "minimal" installation option.
+      - libselinux-utils
     scripts:
       # preinstall: ./scripts/rpm/preinstall.sh
       postinstall: ./scripts/rpm/postinstall.sh

--- a/packages/stable/nfpm.yaml
+++ b/packages/stable/nfpm.yaml
@@ -51,6 +51,10 @@ contents:
 
 overrides:
   rpm:
+    depends:
+      # Provides selinuxenabled tool.
+      # Installed by default even via the "minimal" installation option.
+      - libselinux-utils
     scripts:
       # preinstall: ./scripts/rpm/preinstall.sh
       postinstall: ./scripts/rpm/postinstall.sh

--- a/packages/stable/scripts/rpm/postinstall.sh
+++ b/packages/stable/scripts/rpm/postinstall.sh
@@ -22,17 +22,32 @@ plugin_path="/usr/lib64/nagios/plugins"
 
 # Set required SELinux context to allow plugin use when SELinux is enabled.
 if [ -f "${plugin_path}/${plugin_name}" ]; then
-    chcon \
-        --verbose \
-        -t nagios_unconfined_plugin_exec_t \
-        -u system_u \
-        -r object_r \
-        /usr/lib64/nagios/plugins/check_cert
 
-    if [ $? -eq 0 ]; then
-        echo "Successfully applied SELinux contexts on ${plugin_path}/${plugin_name}"
+    # Make sure we can locate the selinuxenabled binary.
+    if [ -x "$(command -v selinuxenabled)" ]; then
+        selinuxenabled
+
+        if [ $? -ne 0 ]; then
+            echo -e "\nSELinux is not enabled, skipping application of contexts."
+        else
+            # SELinux is enabled. Set context.
+            echo -e "\nApplying SELinux contexts on ${plugin_path}/${plugin_name} ..."
+            chcon \
+                --verbose \
+                -t nagios_unconfined_plugin_exec_t \
+                -u system_u \
+                -r object_r \
+                ${plugin_path}/${plugin_name}
+
+            if [ $? -eq 0 ]; then
+                echo "Successfully applied SELinux contexts on ${plugin_path}/${plugin_name}"
+            else
+                echo "Failed to set SELinux contexts on ${plugin_path}/${plugin_name}"
+            fi
+        fi
+
     else
-        echo "Failed to set SELinux contexts on ${plugin_path}/${plugin_name}"
+        echo "Error: Failed to locate selinuxenabled command." >&2
     fi
 
 else


### PR DESCRIPTION
- Assert that SELinux is enabled before using `chcon` to apply context to installed plugin
- Add dependency on `libselinux-utils` package

fixes GH-509