### PR TITLE
Use WARNING state for unexpected cert file content

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -125,7 +125,7 @@ func main() {
 			))
 			plugin.ServiceOutput = fmt.Sprintf(
 				"%s: Unknown data encountered while parsing certificates file %q",
-				nagios.StateCRITICALLabel,
+				nagios.StateWARNINGLabel,
 				cfg.Filename,
 			)
 
@@ -137,7 +137,7 @@ func main() {
 				nagios.CheckOutputEOL,
 				string(parseAttemptLeftovers),
 			)
-			plugin.ExitStatusCode = nagios.StateCRITICALExitCode
+			plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 
 			return
 		}


### PR DESCRIPTION
Per Nagios Plugin Guidelines, we return a WARNING state when parsing/encountering unexpected certificate file content instead of a CRITICAL state (reserved for "not running" or "above critical threshold" results).

refs GH-464
https://nagios-plugins.org/doc/guidelines.html