### PR TITLE
Generate dev packages for release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,14 @@ goclean:
 ## clean: alias for goclean
 clean: goclean
 
+.PHONY: clean-linux-x64-dev
+## clean-linux-x64-dev: removes dev assets for Linux x64 distros
+clean-linux-x64-dev:
+	@echo "Removing dev build assets used to generate dev packages"
+	@for target in $(WHAT); do \
+		rm -vf $(ASSETS_PATH)/$${target}/$$target-linux-amd64-dev; \
+	done
+
 .PHONY: gitclean
 ## gitclean: WARNING - recursively cleans working tree by removing non-versioned files
 gitclean:
@@ -741,7 +749,7 @@ dev-build: clean linux-x64-dev-build packages-dev package-links linux-x64-dev-co
 
 .PHONY: release-build
 ## release-build: generates stable build assets for public release
-release-build: clean windows linux-x86 packages-stable linux-x64-compress linux-x64-checksums links
+release-build: clean windows linux-x86 packages-dev clean-linux-x64-dev packages-stable linux-x64-compress linux-x64-checksums links
 	@echo "Completed all tasks for stable release build"
 
 .PHONY: helper-docker-builder-setup


### PR DESCRIPTION
The `check-cert-dev` DEB and RPM packages are now generated alongside the `check-cert` DEB and RPM packages. This is to allow configuring a monitoring instance to have "test" service checks that use a "dev" command definition/plugin in addition to the standard/normal/prod command definition/plugin. This allows testing new plugin releases gradually before deploying a new stable version (used by potentially hundreds of service checks).

fixes GH-541