### PR TITLE
Fix lscert Windows binary InternalName metadata

### DIFF
--- a/cmd/lscert/winres/winres.json
+++ b/cmd/lscert/winres/winres.json
@@ -37,7 +37,7 @@
             "CompanyName": "github.com/atc0005",
             "FileDescription": "CLI app used to generate a summary of certificate chain metadata and validation results.",
             "FileVersion": "",
-            "InternalName": "check_cert",
+            "InternalName": "lscert",
             "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
             "LegalTrademarks": "",
             "OriginalFilename": "main.go",


### PR DESCRIPTION
The InternalName field was incorrectly set to `check_cert` instead of `lscert` as intended.