### PR TITLE
Add missing return for perfdata add failure case

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -413,6 +413,8 @@ func main() {
 			"%s: Failed to process performance data metrics",
 			nagios.StateUNKNOWNLabel,
 		)
+
+		return
 	}
 
 	switch {


### PR DESCRIPTION
This was missed when recently refactoring exit state handling.

refs GH-464
refs GH-536