### PR TITLE
Fix "if-return" revive linting error

### DIFF
--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -139,10 +139,6 @@ func (c *Config) setupLogging(appType AppType) error {
 			Logger()
 	}
 
-	if err := setLoggingLevel(c.LoggingLevel); err != nil {
-		return err
-	}
-
-	return nil
+	return setLoggingLevel(c.LoggingLevel)
 
 }


### PR DESCRIPTION
Returning error directly instead of applying conditional check (as an early exit point in case we were to extend the Config.setupLogging func later).

fixes GH-553