### PR TITLE
Fix "unused-parameter" revive linting error

### DIFF
--- a/cmd/check_cert/validate.go
+++ b/cmd/check_cert/validate.go
@@ -66,7 +66,6 @@ func runValidationChecks(cfg *config.Config, certChain []*x509.Certificate, log 
 
 	sansValidationResult := certs.ValidateSANsList(
 		certChain,
-		cfg.DNSName,
 		cfg.SANsEntries,
 		sansValidationOptions,
 	)

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -278,7 +278,6 @@ func main() {
 
 	sansValidationResult := certs.ValidateSANsList(
 		certChain,
-		cfg.DNSName,
 		cfg.SANsEntries,
 		certs.CertChainValidationOptions{
 			IgnoreValidationResultSANs: !cfg.ApplyCertSANsListValidationResults(),

--- a/internal/certs/validation-sans.go
+++ b/internal/certs/validation-sans.go
@@ -79,7 +79,6 @@ type SANsListValidationResult struct {
 // config package.
 func ValidateSANsList(
 	certChain []*x509.Certificate,
-	dnsName string,
 	requiredEntries []string,
 	validationOptions CertChainValidationOptions,
 ) SANsListValidationResult {


### PR DESCRIPTION
Presumably the DNS Name parameter was used for SANs validation at some point, but is correctly identified by the revive linter as not being currently used.

Remove it until needed.

fixes GH-555