### PR TITLE
Fix "unused-parameter" revive linting error

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -427,7 +427,7 @@ func main() {
 		}
 
 		plugin.ServiceOutput = validationResults.OneLineSummary()
-		plugin.LongServiceOutput = validationResults.Report(cfg.VerboseOutput)
+		plugin.LongServiceOutput = validationResults.Report()
 
 		plugin.ExitStatusCode = validationResults.ServiceState().ExitCode
 
@@ -442,7 +442,7 @@ func main() {
 	default:
 
 		plugin.ServiceOutput = validationResults.OneLineSummary()
-		plugin.LongServiceOutput = validationResults.Report(cfg.VerboseOutput)
+		plugin.LongServiceOutput = validationResults.Report()
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 		log.Debug().

--- a/internal/certs/validation-results.go
+++ b/internal/certs/validation-results.go
@@ -687,10 +687,9 @@ func (ccvr CertChainValidationResults) OneLineSummary() string {
 }
 
 // Report returns a formatted report suitable for display and notification
-// purposes. If specified, additional details are provided. The caller is
-// responsible for calling the Sort method first in order to arrange the
-// validation results by appropriate priority.
-func (ccvr CertChainValidationResults) Report(verbose bool) string {
+// purposes. The caller is responsible for calling the Sort method first in
+// order to arrange the validation results by appropriate priority.
+func (ccvr CertChainValidationResults) Report() string {
 
 	// Early exit; we have an empty validation results collection. This should
 	// not be possible as config validation should protect against a sysadmin


### PR DESCRIPTION
Remove "verbose" parameter from the collections-based CertChainValidationResults.Report function as it is not being used.

Looking at the design I can see what I had planned to use it for, but ultimately did not go that path. We can add this back later if needed.

fixes GH-554