### PR TITLE
Fix some errwrap linting errors

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,7 +165,7 @@ func (mvi *multiValueIntFlag) Set(value string) error {
 		port, strConvErr := strconv.Atoi(strings.TrimSpace(v))
 		if strConvErr != nil {
 			return fmt.Errorf(
-				"error processing flag; failed to convert string %q to int: %v",
+				"error processing flag; failed to convert string %q to int: %w",
 				v,
 				strConvErr,
 			)

--- a/internal/netutils/net.go
+++ b/internal/netutils/net.go
@@ -351,7 +351,7 @@ func ExpandHost(hostPattern string) (HostPattern, error) {
 		if IsCIDR(hostPattern) {
 			ipAddrs, _, err := CIDRHosts(hostPattern)
 			if err != nil {
-				return HostPattern{}, fmt.Errorf("error parsing CIDR range: %s", err)
+				return HostPattern{}, fmt.Errorf("error parsing CIDR range: %w", err)
 			}
 			// fmt.Printf("%q is a CIDR rangeof %d IPs\n", s, count)
 


### PR DESCRIPTION
Resolve two of four linting issues identified by the errwrap linter.

The remaining two linting issues appear to be false-positives and will be considered as part of future work.

refs GH-564