### PR TITLE
Conditionally join days/hours before expiration

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -668,8 +668,16 @@ func FormattedExpiration(expireTime time.Time) string {
 
 	hoursRemainingStr = fmt.Sprintf("%dh", int64(hoursRemaining))
 
-	formattedTimeRemainingStr = strings.Join([]string{
-		daysRemainingStr, hoursRemainingStr}, " ")
+	// Only join days and hours remaining if there *are* days remaining.
+	switch {
+	case daysRemainingStr != "":
+		formattedTimeRemainingStr = strings.Join(
+			[]string{daysRemainingStr, hoursRemainingStr},
+			" ",
+		)
+	default:
+		formattedTimeRemainingStr = hoursRemainingStr
+	}
 
 	switch {
 	case !certExpired:


### PR DESCRIPTION
If there are days remaining join it with hours remaining, otherwise use just the hours remaining for the formatted expiration value.

fixes GH-579