### PR TITLE
Fix TCP port flag validation

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -131,6 +131,7 @@ func TestConfigValidationForCheckResultsFlags(t *testing.T) {
 		{
 			name: "DefaultValidateExpirationResults",
 			cfg: Config{
+				Port:         443,
 				LoggingLevel: defaultLogLevel,
 				Server:       "www.example.com",
 				AgeWarning:   defaultCertExpireAgeWarning,
@@ -141,6 +142,7 @@ func TestConfigValidationForCheckResultsFlags(t *testing.T) {
 		{
 			name: "IgnoreValidateExpirationResults",
 			cfg: Config{
+				Port:                    443,
 				LoggingLevel:            defaultLogLevel,
 				Server:                  "www.example.com",
 				AgeWarning:              defaultCertExpireAgeWarning,
@@ -152,6 +154,7 @@ func TestConfigValidationForCheckResultsFlags(t *testing.T) {
 		{
 			name: "ApplyValidateExpirationResults",
 			cfg: Config{
+				Port:                   443,
 				LoggingLevel:           defaultLogLevel,
 				Server:                 "www.example.com",
 				AgeWarning:             defaultCertExpireAgeWarning,
@@ -163,6 +166,7 @@ func TestConfigValidationForCheckResultsFlags(t *testing.T) {
 		{
 			name: "DefaultValidateHostnameResults",
 			cfg: Config{
+				Port:         443,
 				LoggingLevel: defaultLogLevel,
 				Server:       "www.example.com",
 				AgeWarning:   defaultCertExpireAgeWarning,
@@ -173,6 +177,7 @@ func TestConfigValidationForCheckResultsFlags(t *testing.T) {
 		{
 			name: "IgnoreValidateHostnameResults",
 			cfg: Config{
+				Port:                    443,
 				LoggingLevel:            defaultLogLevel,
 				Server:                  "www.example.com",
 				AgeWarning:              defaultCertExpireAgeWarning,
@@ -184,6 +189,7 @@ func TestConfigValidationForCheckResultsFlags(t *testing.T) {
 		{
 			name: "ApplyValidateHostnameResults",
 			cfg: Config{
+				Port:                   443,
 				LoggingLevel:           defaultLogLevel,
 				Server:                 "www.example.com",
 				AgeWarning:             defaultCertExpireAgeWarning,
@@ -195,6 +201,7 @@ func TestConfigValidationForCheckResultsFlags(t *testing.T) {
 		{
 			name: "DefaultValidateSANsListResultsWithoutSANsEntries",
 			cfg: Config{
+				Port:         443,
 				LoggingLevel: defaultLogLevel,
 				Server:       "www.example.com",
 				AgeWarning:   defaultCertExpireAgeWarning,
@@ -205,6 +212,7 @@ func TestConfigValidationForCheckResultsFlags(t *testing.T) {
 		{
 			name: "DefaultValidateSANsListResultsWithSANsEntries",
 			cfg: Config{
+				Port:         443,
 				LoggingLevel: defaultLogLevel,
 				Server:       "www.example.com",
 				AgeWarning:   defaultCertExpireAgeWarning,
@@ -216,6 +224,7 @@ func TestConfigValidationForCheckResultsFlags(t *testing.T) {
 		{
 			name: "IgnoreValidateSANsListResults",
 			cfg: Config{
+				Port:                    443,
 				LoggingLevel:            defaultLogLevel,
 				Server:                  "www.example.com",
 				AgeWarning:              defaultCertExpireAgeWarning,
@@ -227,6 +236,7 @@ func TestConfigValidationForCheckResultsFlags(t *testing.T) {
 		{
 			name: "ApplyValidateSANsListResultsWithSANsEntries",
 			cfg: Config{
+				Port:                   443,
 				LoggingLevel:           defaultLogLevel,
 				Server:                 "www.example.com",
 				AgeWarning:             defaultCertExpireAgeWarning,
@@ -239,6 +249,7 @@ func TestConfigValidationForCheckResultsFlags(t *testing.T) {
 		{
 			name: "ApplyValidateSANsListResultsWithoutSANsEntries",
 			cfg: Config{
+				Port:                   443,
 				LoggingLevel:           defaultLogLevel,
 				Server:                 "www.example.com",
 				AgeWarning:             defaultCertExpireAgeWarning,

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -243,3 +243,18 @@ const (
 // limit number of IP Addresses "printed" by the Stringer interface to a
 // human-readable number
 const mvhPrintLimit int = 50
+
+// TCP port ranges
+// http://www.iana.org/assignments/port-numbers
+// Port numbers are assigned in various ways, based on three ranges: System
+// Ports (0-1023), User Ports (1024-49151), and the Dynamic and/or Private
+// Ports (49152-65535)
+const (
+	tcpReservedPort            int = 0
+	tcpSystemPortStart         int = 1
+	tcpSystemPortEnd           int = 1023
+	tcpUserPortStart           int = 1024
+	tcpUserPortEnd             int = 49151
+	tcpDynamicPrivatePortStart int = 49152
+	tcpDynamicPrivatePortEnd   int = 65535
+)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -192,8 +192,17 @@ func (c Config) validate(appType AppType) error {
 		// value "show" flags
 	}
 
-	if c.Port < 0 {
-		return fmt.Errorf("invalid TCP port number %d", c.Port)
+	// TCP Port 0 is used by server applications to indicate that they should
+	// bind to an available port. Specifying port 0 for a client application
+	// is not useful.
+	if c.Port <= 0 {
+		return fmt.Errorf(
+			"invalid TCP port number; got %d,"+
+				" expected value between %d and %d (e.g., 443, 636)",
+			c.Port,
+			tcpSystemPortStart,
+			tcpDynamicPrivatePortEnd,
+		)
 	}
 
 	if c.Timeout() < 0 {


### PR DESCRIPTION
Previous validation unintentionally allowed specifying 0 as the destination TCP port.

While useful for a server application (auto-bind behavior) this is not useful for a client application intended to connect to a specific target port.

Update validation to disallow specifying zero as a TCP port value and offer feedback indicating the valid start/end port range, including brief examples of common ports.