### PR TITLE
Fix helper function closure collection evaluation

### DIFF
--- a/cmd/check_cert/annotations.go
+++ b/cmd/check_cert/annotations.go
@@ -68,7 +68,7 @@ func annotateError(logger zerolog.Logger, errs ...error) []error {
 
 	isNilErrCollection := func(collection []error) bool {
 		if len(collection) != 0 {
-			for _, err := range errs {
+			for _, err := range collection {
 				if err != nil {
 					return false
 				}


### PR DESCRIPTION
Range over function closure argument instead of error collection from outside of function body.