### PR TITLE
Update error annotation implementation

### DIFF
--- a/cmd/check_cert/annotations.go
+++ b/cmd/check_cert/annotations.go
@@ -8,120 +8,33 @@
 package main
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"syscall"
-	"time"
+	// "syscall"
 
-	"github.com/rs/zerolog"
+	"github.com/atc0005/go-nagios"
 )
-
-// errRuntimeTimeoutReached indicates that plugin runtime exceeded specified
-// timeout value.
-var errRuntimeTimeoutReached = errors.New("plugin runtime exceeded specified timeout value")
-
-// runtimeTimeoutReachedAdvice offers advice to the sysadmin for routine
-// occurrence.
-const runtimeTimeoutReachedAdvice string = "consider increasing value if this is routinely encountered"
 
 // connectionResetByPeerAdvice offers advice to the sysadmin to check the
 // certificate/port bindings when a "read: connection reset by peer" error is
 // encountered. An IIS site with a missing binding has been observed in the
 // field as a cause of this issue.
-const connectionResetByPeerAdvice string = "consider checking certificate/port bindings (e.g., IIS Site Bindings)"
-
-// connectionRefusedAdvice offers advice to the sysadmin to check the
-// specified port and remote service state. The "connect: connection refused"
-// error is often encountered when an application associated with the
-// certificate being checked is stopped (e.g., troubleshooting purposes,
-// replacing a certificate or the service has crashed) or if the wrong
-// port was specified for a service.
-const connectionRefusedAdvice string = "consider double-checking specified port and remote service state (i.e., make sure service is actually running on given port)"
+// const connectionResetByPeerAdvice string = "consider checking certificate/port bindings (e.g., IIS Site Bindings)"
 
 // annotateError is a helper function used to add additional human-readable
-// explanation for errors commonly emitted by dependencies.
-//
-// This function receives a logger and one or more errors, evaluates whether
-// any contain specific errors in its chain and then (potentially) appends
-// additional details for later use. This updated collection of error chains
-// are returned to the caller, preserving any original wrapped errors.
-//
-// The original error collection is returned unmodified if no annotations were
-// deemed necessary.
-//
-// Nil is returned if an empty collection or a collection of nil values are
-// provided for evaluation.
-func annotateError(logger zerolog.Logger, errs ...error) []error {
-
-	funcTimeStart := time.Now()
-
-	var errsAnnotated int
-	defer func(counter *int) {
-		logger.Printf(
-			"It took %v to execute annotateError func (errors evaluated: %d, annotated: %d)",
-			time.Since(funcTimeStart),
-			len(errs),
-			*counter,
-		)
-	}(&errsAnnotated)
-
-	isNilErrCollection := func(collection []error) bool {
-		if len(collection) != 0 {
-			for _, err := range collection {
-				if err != nil {
-					return false
-				}
-			}
-		}
-		return true
+// explanation for errors encountered during plugin execution. We first apply
+// common advice for more general errors then apply advice specific to errors
+// routinely encountered by this specific project.
+func annotateErrors(plugin *nagios.Plugin) {
+	// If nothing to process, skip setup/processing steps.
+	if len(plugin.Errors) == 0 {
+		return
 	}
 
-	switch {
+	// Start off with the default advice collection.
+	errorAdviceMap := nagios.DefaultErrorAnnotationMappings()
 
-	// Process errors as long as the collection is not empty or not composed
-	// entirely of nil values.
-	case !isNilErrCollection(errs):
-		annotatedErrors := make([]error, 0, len(errs))
+	// Override specific error with project-specific feedback.
+	// errorAdviceMap[syscall.ECONNRESET] = connectionResetByPeerAdvice
 
-		for _, err := range errs {
-			if err != nil {
-				switch {
-				case errors.Is(err, context.DeadlineExceeded):
-					annotatedErrors = append(annotatedErrors, fmt.Errorf(
-						"%w: %s; %s",
-						err,
-						errRuntimeTimeoutReached,
-						runtimeTimeoutReachedAdvice,
-					))
-
-				case errors.Is(err, syscall.ECONNRESET):
-					annotatedErrors = append(annotatedErrors, fmt.Errorf(
-						"%w: %s",
-						err,
-						connectionResetByPeerAdvice,
-					))
-
-				case errors.Is(err, syscall.ECONNREFUSED):
-					annotatedErrors = append(annotatedErrors, fmt.Errorf(
-						"%w: %s",
-						err,
-						connectionRefusedAdvice,
-					))
-
-				default:
-					// Record error unmodified if additional decoration isn't defined
-					// for the error type.
-					annotatedErrors = append(annotatedErrors, err)
-				}
-			}
-		}
-
-		return annotatedErrors
-
-	// No errors were provided for evaluation.
-	default:
-		return nil
-	}
-
+	// Apply error advice annotations.
+	plugin.AnnotateRecordedErrors(errorAdviceMap)
 }

--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -61,12 +61,9 @@ func main() {
 		return
 	}
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin, logger zerolog.Logger) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = annotateError(logger, plugin.Errors...)
-	}(plugin, cfg.Log)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer annotateErrors(plugin)
 
 	if cfg.EmitBranding {
 		// If enabled, show application details at end of notification


### PR DESCRIPTION
Switch from local error annotation implementation to upstream implementation. The project specific error advice is commented out instead of completely removed for the time being.