### PR TITLE
Fix textutils.BytesToDelimitedHexStr logic

### DIFF
--- a/internal/textutils/textutils.go
+++ b/internal/textutils/textutils.go
@@ -124,11 +124,23 @@ func InsertDelimiter(s string, delimiter string, pos int) string {
 
 // BytesToDelimitedHexStr converts a byte slice to a delimited hex string.
 func BytesToDelimitedHexStr(bx []byte, delimiter string) string {
-	hexStr := make([]string, 0, len(bx))
-	for _, v := range bx {
-		hexStr = append(hexStr, fmt.Sprintf("%X", v))
-	}
-	return strings.Join(hexStr, delimiter)
+	// hexStr := make([]string, 0, len(bx))
+	// for _, v := range bx {
+	// 	hexStr = append(hexStr, fmt.Sprintf(
+	// 		// Pad single digits with a leading zero.
+	// 		// see also atc0005/check-cert#706
+	// 		"%02X", v,
+	// 	))
+	// }
+	// return strings.Join(hexStr, delimiter)
+
+	hexStr := fmt.Sprintf("%X", bx)
+	delimiterPosition := 2
+
+	formattedHexStr := InsertDelimiter(hexStr, delimiter, delimiterPosition)
+	formattedHexStr = strings.ToUpper(formattedHexStr)
+
+	return formattedHexStr
 }
 
 // Matches returns a list of successful matches and a list of failed matches


### PR DESCRIPTION
## Changes

Apply base 16 string formatting to entire byte slice instead of to each individual byte within the slice. This retains the expected leading zero for formatted bytes.

We also reuse textutils.InsertDelimiter to provide formatting of the hex string instead of duplicating the logic.

I left a commented out hotfix for later review/consideration (or cleanup).

## References

- fixes GH-706