### PR TITLE
Fix errcheck linting errors

### DIFF
--- a/cmd/certsum/summary.go
+++ b/cmd/certsum/summary.go
@@ -49,20 +49,20 @@ func printSummaryHighLevel(
 	switch {
 	case hasHostNameVal:
 		// Header row in output
-		fmt.Fprintf(tw,
+		_, _ = fmt.Fprintf(tw,
 			"Host (Name/FQDN)\tIP Addr\tPort\tSubject or SANs\tStatus\tChain Summary\tSerial\n")
 
 		// Separator row
-		fmt.Fprintln(tw,
+		_, _ = fmt.Fprintln(tw,
 			"---\t---\t---\t---\t---\t---\t---")
 
 	default:
 		// Header row in output
-		fmt.Fprintf(tw,
+		_, _ = fmt.Fprintf(tw,
 			"Host\tPort\tSubject or SANs\tStatus\tChain Summary\tSerial\n")
 
 		// Separator row
-		fmt.Fprintln(tw,
+		_, _ = fmt.Fprintln(tw,
 			"---\t---\t---\t---\t---\t---")
 	}
 
@@ -109,7 +109,7 @@ func printSummaryHighLevel(
 
 		switch {
 		case hasHostNameVal:
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				tw,
 				"%v\t%v\t%v\t%v\t%s\t%v\t%v\n",
 				certChain.Name,
@@ -121,7 +121,7 @@ func printSummaryHighLevel(
 				certs.FormatCertSerialNumber(certChain.Certs[0].SerialNumber),
 			)
 		default:
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				tw,
 				"%v\t%v\t%v\t%s\t%v\t%v\n",
 				certChain.IPAddress,
@@ -135,7 +135,7 @@ func printSummaryHighLevel(
 
 	}
 
-	fmt.Fprintln(tw)
+	_, _ = fmt.Fprintln(tw)
 	if err := tw.Flush(); err != nil {
 		log.Printf(
 			"error occurred flushing tabwriter: %v",
@@ -182,20 +182,20 @@ func printSummaryDetailedLevel(
 	switch {
 	case hasHostNameVal:
 		// Header row in output
-		fmt.Fprintf(tw,
+		_, _ = fmt.Fprintf(tw,
 			"Host (Name/FQDN)\tIP Addr\tPort\tSubject or SANs\tStatus (Type)\tSummary\tSerial\n")
 
 		// Separator row
-		fmt.Fprintln(tw,
+		_, _ = fmt.Fprintln(tw,
 			"---\t---\t---\t---\t---\t---\t---")
 
 	default:
 		// Header row in output
-		fmt.Fprintf(tw,
+		_, _ = fmt.Fprintf(tw,
 			"Host\tPort\tSubject or SANs\tStatus (Type)\tSummary\tSerial\n")
 
 		// Separator row
-		fmt.Fprintln(tw,
+		_, _ = fmt.Fprintln(tw,
 			"---\t---\t---\t---\t---\t---")
 	}
 
@@ -230,7 +230,7 @@ func printSummaryDetailedLevel(
 
 			switch {
 			case hasHostNameVal:
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					tw,
 					"%v\t%v\t%v\t%v\t%s (%s)\t%v\t%v\n",
 					certChain.Name,
@@ -243,7 +243,7 @@ func printSummaryDetailedLevel(
 					certs.FormatCertSerialNumber(cert.SerialNumber),
 				)
 			default:
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					tw,
 					"%v\t%v\t%v\t%s (%s)\t%v\t%v\n",
 					certChain.IPAddress,
@@ -260,7 +260,7 @@ func printSummaryDetailedLevel(
 
 	}
 
-	fmt.Fprintln(tw)
+	_, _ = fmt.Fprintln(tw)
 	if err := tw.Flush(); err != nil {
 		log.Printf(
 			"error occurred flushing tabwriter: %v",

--- a/internal/certs/validation-results.go
+++ b/internal/certs/validation-results.go
@@ -706,7 +706,7 @@ func (ccvr CertChainValidationResults) Report() string {
 	// Ensure results are sorted prior to generated report output.
 	ccvr.Sort()
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&summary,
 		"%s%sPROBLEM RESULTS:%s",
 		nagios.CheckOutputEOL,
@@ -716,7 +716,7 @@ func (ccvr CertChainValidationResults) Report() string {
 
 	switch {
 	case !ccvr.HasFailed():
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&summary,
 			"%s* None%s",
 			nagios.CheckOutputEOL,
@@ -725,7 +725,7 @@ func (ccvr CertChainValidationResults) Report() string {
 	default:
 		for _, result := range ccvr {
 			if !result.IsOKState() {
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					&summary,
 					// "\xE2\x9B\x94 [!!] %s%s",
 					"%s[!!] %s%s",
@@ -737,7 +737,7 @@ func (ccvr CertChainValidationResults) Report() string {
 		}
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&summary,
 		"%s%sIGNORED RESULTS:%s",
 		nagios.CheckOutputEOL,
@@ -747,7 +747,7 @@ func (ccvr CertChainValidationResults) Report() string {
 
 	switch {
 	case !ccvr.HasIgnored():
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&summary,
 			"%s* None%s",
 			nagios.CheckOutputEOL,
@@ -756,7 +756,7 @@ func (ccvr CertChainValidationResults) Report() string {
 	default:
 		for _, result := range ccvr {
 			if result.IsIgnored() {
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					&summary,
 					// "\u23ED\uFE0F [--] %s%s",
 					"%s[--] %s%s",
@@ -768,7 +768,7 @@ func (ccvr CertChainValidationResults) Report() string {
 		}
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&summary,
 		"%s%sSUCCESS RESULTS:%s",
 		nagios.CheckOutputEOL,
@@ -778,7 +778,7 @@ func (ccvr CertChainValidationResults) Report() string {
 
 	switch {
 	case !ccvr.HasSucceeded():
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&summary,
 			"%s* None%s",
 			nagios.CheckOutputEOL,
@@ -787,7 +787,7 @@ func (ccvr CertChainValidationResults) Report() string {
 	default:
 		for _, result := range ccvr {
 			if result.IsSucceeded() {
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					&summary,
 					// "\xE2\x9C\x85 [OK] %s%s",
 					"%s[OK] %s%s",

--- a/internal/certs/validation-sans.go
+++ b/internal/certs/validation-sans.go
@@ -395,7 +395,7 @@ func (slvr SANsListValidationResult) StatusDetail() string {
 			unexpected = strings.Join(slvr.unmatchedSANsEntriesFromCert, ", ")
 		}
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&detail,
 			"missing: [%s], unexpected: [%s]",
 			missing,

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -247,10 +247,10 @@ func (c *Config) handleFlagsConfig(appType AppType) {
 		// with the `--help` flag and have it display within the Admin web UI.
 		flag.CommandLine.SetOutput(os.Stdout)
 
-		fmt.Fprintln(flag.CommandLine.Output(), headerText)
+		_, _ = fmt.Fprintln(flag.CommandLine.Output(), headerText)
 		flag.PrintDefaults()
-		fmt.Fprintln(flag.CommandLine.Output(), positionalArgRequirements)
-		fmt.Fprintln(flag.CommandLine.Output(), footerText)
+		_, _ = fmt.Fprintln(flag.CommandLine.Output(), positionalArgRequirements)
+		_, _ = fmt.Fprintln(flag.CommandLine.Output(), footerText)
 	}
 
 	// parse flag definitions from the argument list


### PR DESCRIPTION
Resolve `return value of fmt.Fprintf is not checked`` errors by
explicitly discarding return values (potential error, bytes written)
since we do not need them and the potential for failure (in this
particular use case) is *highly* unlikely.
