### PR TITLE
Add new tool to support copying/filtering certs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@
 SHELL := /bin/bash
 
 # Space-separated list of cmd/BINARY_NAME directories to build
-WHAT 					:= check_cert lscert certsum
+WHAT 					:= check_cert lscert certsum cpcert
 
 PROJECT_NAME			:= check-cert
 

--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -80,7 +80,7 @@ func main() {
 
 	// Honor request to parse filename first
 	switch {
-	case cfg.Filename != "":
+	case cfg.InputFilename != "":
 
 		log.Debug().Msg("Attempting to parse certificate file")
 
@@ -91,7 +91,7 @@ func main() {
 		var parseAttemptLeftovers []byte
 
 		var err error
-		certChain, parseAttemptLeftovers, err = certs.GetCertsFromFile(cfg.Filename)
+		certChain, parseAttemptLeftovers, err = certs.GetCertsFromFile(cfg.InputFilename)
 		if err != nil {
 			log.Error().Err(err).Msg(
 				"Error parsing certificates file")
@@ -100,14 +100,14 @@ func main() {
 			plugin.ServiceOutput = fmt.Sprintf(
 				"%s: Error parsing certificates file %q",
 				nagios.StateCRITICALLabel,
-				cfg.Filename,
+				cfg.InputFilename,
 			)
 			plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 			return
 		}
 
-		certChainSource = cfg.Filename
+		certChainSource = cfg.InputFilename
 
 		log.Debug().Msg("Certificate file parsed")
 
@@ -118,18 +118,18 @@ func main() {
 			plugin.AddError(fmt.Errorf(
 				"%d unknown/unparsed bytes remaining at end of cert file %q",
 				len(parseAttemptLeftovers),
-				cfg.Filename,
+				cfg.InputFilename,
 			))
 			plugin.ServiceOutput = fmt.Sprintf(
 				"%s: Unknown data encountered while parsing certificates file %q",
 				nagios.StateWARNINGLabel,
-				cfg.Filename,
+				cfg.InputFilename,
 			)
 
 			plugin.LongServiceOutput = fmt.Sprintf(
 				"The following text from the %q certificate file failed to parse"+
 					" and is provided here for troubleshooting purposes:%s%s%s",
-				cfg.Filename,
+				cfg.InputFilename,
 				nagios.CheckOutputEOL,
 				nagios.CheckOutputEOL,
 				string(parseAttemptLeftovers),
@@ -353,7 +353,7 @@ func main() {
 		// both cases?
 		var template string
 		switch {
-		case cfg.Filename != "":
+		case cfg.InputFilename != "":
 			template = "%d certs found in %s%s%s"
 		default:
 			template = "%d certs retrieved for %s%s%s"

--- a/cmd/cpcert/doc.go
+++ b/cmd/cpcert/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// CLI app used to copy and manipulate certificates.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/check-cert
+package main

--- a/cmd/cpcert/filter.go
+++ b/cmd/cpcert/filter.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"crypto/x509"
+
+	"github.com/atc0005/check-cert/internal/certs"
+	"github.com/atc0005/check-cert/internal/config"
+	"github.com/atc0005/check-cert/internal/textutils"
+)
+
+// filterCertChain filters the given certificate chain to the specified list
+// of certificate types.
+func filterCertChain(filterKeywords []string, certChain []*x509.Certificate) []*x509.Certificate {
+	filteredCertChain := make([]*x509.Certificate, 0, len(certChain))
+
+	// Validation prevents other keywords from being specified alongside this
+	// one.
+	if textutils.InList(config.CertTypeAll, filterKeywords, true) {
+		filteredCertChain = append(filteredCertChain, certChain...)
+	}
+
+	if textutils.InList(config.CertTypeLeaf, filterKeywords, true) {
+		for _, cert := range certChain {
+			if certs.IsLeafCert(cert, certChain) {
+				filteredCertChain = append(filteredCertChain, cert)
+			}
+		}
+	}
+
+	if textutils.InList(config.CertTypeIntermediate, filterKeywords, true) {
+		for _, cert := range certChain {
+			if certs.IsIntermediateCert(cert, certChain) {
+				filteredCertChain = append(filteredCertChain, cert)
+			}
+		}
+	}
+
+	if textutils.InList(config.CertTypeRoot, filterKeywords, true) {
+		for _, cert := range certChain {
+			if certs.IsRootCert(cert, certChain) {
+				filteredCertChain = append(filteredCertChain, cert)
+			}
+		}
+	}
+
+	return filteredCertChain
+}

--- a/cmd/cpcert/main.go
+++ b/cmd/cpcert/main.go
@@ -1,0 +1,337 @@
+// Copyright 2024 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
+package main
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-cert/internal/certs"
+	"github.com/atc0005/check-cert/internal/config"
+	"github.com/atc0005/check-cert/internal/netutils"
+	"github.com/atc0005/check-cert/internal/textutils"
+	"github.com/atc0005/go-nagios"
+)
+
+func main() {
+	// Setup configuration by parsing user-provided flags.
+	cfg, cfgErr := config.New(config.AppType{Copier: true})
+	switch {
+	case errors.Is(cfgErr, config.ErrVersionRequested):
+		fmt.Println(config.Version())
+
+		return
+
+	case cfgErr != nil:
+
+		// We make some assumptions when setting up our logger as we do not
+		// have a working configuration based on sysadmin-specified choices.
+		consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr}
+		logger := zerolog.New(consoleWriter).With().Timestamp().Caller().Logger()
+
+		logger.Err(cfgErr).Msg("Error initializing application")
+
+		return
+	}
+
+	// Emulate returning exit code from main function by "queuing up" a
+	// default exit code that matches expectations, but allow explicitly
+	// setting the exit code in such a way that is compatible with using
+	// deferred function calls throughout the application.
+	var appExitCode int
+	defer func(code *int) {
+		var exitCode int
+		if code != nil {
+			exitCode = *code
+		}
+		os.Exit(exitCode)
+	}(&appExitCode)
+
+	log := cfg.Log.With().Logger()
+
+	var certChain []*x509.Certificate
+
+	// Anything from the specified file that couldn't be converted to a
+	// certificate chain. While likely not of high value, it could help
+	// identify why a certificate isn't being properly trusted by a client
+	// application, so emitting it may be useful to the user of this
+	// application.
+	var parseAttemptLeftovers []byte
+
+	var certChainSource string
+
+	switch {
+	case cfg.InputFilename != "":
+
+		log.Debug().Msg("Attempting to retrieve certificates from file")
+
+		var err error
+		certChain, parseAttemptLeftovers, err = certs.GetCertsFromFile(cfg.InputFilename)
+		if err != nil {
+			log.Error().Err(err).Msg(
+				"Error parsing certificates file")
+			appExitCode = config.ExitCodeCatchall
+			return
+		}
+
+		certChainSource = cfg.InputFilename
+
+	case cfg.Server != "":
+
+		log.Debug().Msg("Expanding given host pattern in order to obtain IP Address")
+		expandedHost, expandErr := netutils.ExpandHost(cfg.Server)
+		switch {
+		// Provide useful feedback here to cover the case of the INPUT_PATTERN
+		// not existing as a file or resolving as a server value.
+		case expandErr != nil && cfg.PosArgInputPattern != "":
+			log.Error().Err(config.ErrInvalidPosArgPattern).Msgf(
+				"Input pattern %q unrecognized as valid server value or filename",
+				cfg.PosArgInputPattern,
+			)
+			appExitCode = config.ExitCodeCatchall
+			return
+
+		case expandErr != nil:
+			log.Error().Err(expandErr).Msg(
+				"Error expanding given host pattern")
+			appExitCode = config.ExitCodeCatchall
+			return
+
+		// Fail early for IP Ranges. While we could just grab the first
+		// expanded IP Address, this may be a potential source of confusion
+		// best avoided.
+		case expandedHost.Range:
+			log.Error().Msgf(
+				"Given host pattern invalid; " +
+					"host pattern is a CIDR or partial IP range",
+			)
+			appExitCode = config.ExitCodeCatchall
+			return
+
+		case len(expandedHost.Expanded) == 0:
+			log.Error().Msg(
+				"Failed to expand given host value to IP Address")
+			appExitCode = config.ExitCodeCatchall
+			return
+
+		case len(expandedHost.Expanded) > 1:
+
+			ipAddrs := zerolog.Arr()
+			for _, ip := range expandedHost.Expanded {
+				ipAddrs.Str(ip)
+			}
+
+			log.Debug().
+				Int("num_ip_addresses", len(expandedHost.Expanded)).
+				Array("ip_addresses", ipAddrs).
+				Msg("Multiple IP Addresses resolved from given host pattern")
+			log.Debug().Msg("Using first IP Address, ignoring others")
+
+		}
+
+		// Grab first IP Address from the resolved collection. We'll
+		// explicitly use it for cert retrieval and note it in the report
+		// output.
+		ipAddr := expandedHost.Expanded[0]
+
+		// Server Name Indication (SNI) support is used to request a specific
+		// certificate chain from a remote server.
+		//
+		// We use the value specified by the server flag to open a connection
+		// to the remote server. If available, we use the DNS Name value
+		// specified by the DNS Name flag as our host value, otherwise we
+		// fallback to using the value specified by the server flag as our
+		// host value.
+		//
+		// For a service with only one certificate chain the host value is
+		// less important, but for a host with multiple certificate chains
+		// having the correct host value is crucial.
+		var hostVal string
+		switch {
+
+		// We have a resolved IP Address and a sysadmin-specified DNS Name
+		// value to use for a SNI-enabled certificate retrieval attempt.
+		case expandedHost.Resolved && cfg.DNSName != "":
+			hostVal = cfg.DNSName
+			certChainSource = fmt.Sprintf(
+				"service running on %s (%s) at port %d using host value %q",
+				expandedHost.Given,
+				ipAddr,
+				cfg.Port,
+				hostVal,
+			)
+
+		// We have a valid IP Address to use for opening the connection and a
+		// sysadmin-specified DNS Name value to use for a SNI-enabled
+		// certificate retrieval attempt.
+		case cfg.DNSName != "":
+			hostVal = cfg.DNSName
+			certChainSource = fmt.Sprintf(
+				"service running on %s at port %d using host value %q",
+				ipAddr,
+				cfg.Port,
+				hostVal,
+			)
+
+		// We have a resolved IP Address, but not a sysadmin-specified DNS
+		// Name value. We'll use the resolvable name/FQDN for a SNI-enabled
+		// certificate retrieval attempt.
+		case expandedHost.Resolved && cfg.DNSName == "":
+			hostVal = expandedHost.Given
+			certChainSource = fmt.Sprintf(
+				"service running on %s (%s) at port %d using host value %q",
+				expandedHost.Given,
+				ipAddr,
+				cfg.Port,
+				expandedHost.Given,
+			)
+		default:
+			certChainSource = fmt.Sprintf(
+				"service running on %s at port %d",
+				ipAddr,
+				cfg.Port,
+			)
+		}
+
+		log.Debug().
+			Str("server", cfg.Server).
+			Str("dns_name", cfg.DNSName).
+			Str("ip_address", ipAddr).
+			Str("host_value", hostVal).
+			Int("port", cfg.Port).
+			Msg("Retrieving certificate chain")
+		var certFetchErr error
+		certChain, certFetchErr = netutils.GetCerts(
+			hostVal,
+			ipAddr,
+			cfg.Port,
+			cfg.Timeout(),
+			log,
+		)
+		if certFetchErr != nil {
+			log.Error().Err(certFetchErr).Msg(
+				"Error fetching certificates chain")
+			appExitCode = config.ExitCodeCatchall
+			return
+		}
+
+	}
+
+	// Abort immediately if we have nothing to work with.
+	if len(certChain) == 0 {
+		log.Err(certs.ErrNoCertsFound).Msg("")
+		appExitCode = config.ExitCodeCatchall
+		return
+	}
+
+	if len(parseAttemptLeftovers) > 0 {
+		textutils.PrintHeader("CERTIFICATES | UNKNOWN data in cert file")
+
+		fmt.Printf(
+			"The following data (converted to text) was found in the %q input"+
+				" file and is provided here in case it is useful for"+
+				" troubleshooting purposes.\n\n",
+			cfg.InputFilename,
+		)
+
+		fmt.Println(string(parseAttemptLeftovers))
+
+		appExitCode = config.ExitCodeCatchall
+		return
+	}
+
+	// If a certificate chain was pulled from a file, we "found" it, if it
+	// was pulled from a server we "retrieved" it.
+	var template string
+	switch {
+	case cfg.InputFilename != "":
+		template = "%s: %d certs found in %s:\n"
+	default:
+		template = "%s: %d certs retrieved for %s:\n"
+	}
+
+	fmt.Printf(
+		template,
+		nagios.StateOKLabel,
+		len(certChain),
+		certChainSource,
+	)
+
+	if err := printCertChain(os.Stdout, certChain); err != nil {
+		log.Err(err).Msg("failed to print certificate file")
+		appExitCode = config.ExitCodeCatchall
+
+		return
+	}
+
+	filteredCertChain := filterCertChain(cfg.CertTypesToKeep(), certChain)
+	switch {
+	case len(filteredCertChain) == 0:
+		err := errors.New("all certificates in input chain excluded")
+		log.Err(err).Msg("failed to create output certificate file")
+		appExitCode = config.ExitCodeCatchall
+
+		return
+	case len(filteredCertChain) != len(certChain):
+		fmt.Println("OK: Input certificate chain filtered as requested.")
+
+		fmt.Println("\nNew certificate chain:")
+		if err := printCertChain(os.Stdout, filteredCertChain); err != nil {
+			log.Err(err).Msg("failed to print certificate file")
+			appExitCode = config.ExitCodeCatchall
+
+			return
+		}
+	default:
+		fmt.Println("OK: Retaining input certificate chain as-is:")
+
+		if err := printCertChain(os.Stdout, certChain); err != nil {
+			log.Err(err).Msg("failed to print certificate file")
+			appExitCode = config.ExitCodeCatchall
+
+			return
+		}
+	}
+
+	// Open the file to write the certificate chain
+	outputFile, err := os.Create(cfg.OutputFilename)
+	if err != nil {
+		log.Err(err).Msg("failed to create output certificate file")
+		appExitCode = config.ExitCodeCatchall
+		return
+	}
+
+	defer func() {
+		if err := outputFile.Close(); err != nil {
+			log.Err(err).Msg("error occurred closing output file")
+		}
+	}()
+
+	for _, cert := range filteredCertChain {
+		err := certs.WriteCertToPEMFile(outputFile, cert)
+		if err != nil {
+			log.Err(err).Msg("failed to write certificate")
+
+			appExitCode = config.ExitCodeCatchall
+			return
+		}
+	}
+
+	fmt.Printf(
+		"\n%d of %d certs successfully written to %s\n",
+		len(filteredCertChain),
+		len(certChain),
+		cfg.OutputFilename,
+	)
+}

--- a/cmd/cpcert/print.go
+++ b/cmd/cpcert/print.go
@@ -1,0 +1,125 @@
+// Copyright 2024 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"crypto/x509"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/atc0005/check-cert/internal/certs"
+)
+
+func printCertChain(out io.Writer, certChain []*x509.Certificate) error {
+	w := tabwriter.NewWriter(out, 4, 4, 4, ' ', 0)
+
+	certChainPositionColTitle := "Chain Position"
+	certTypeColTitle := "Cert Type"
+	subjectColTitle := "Subject"
+	issuerCertificateURLsTitle := "Issuer Certificate URLs"
+
+	certChainPositionSeparatorLength := func() int {
+		longest := len(certChainPositionColTitle)
+
+		if len(certChain) > longest {
+			longest = len(certChain) + 1
+		}
+
+		return longest
+	}
+
+	certTypeSeparatorLength := func() int {
+		longest := len(certTypeColTitle)
+		for _, cert := range certChain {
+			certType := certs.ChainPosition(cert, certChain)
+
+			if len(certType) > longest {
+				longest = len(certType)
+			}
+		}
+
+		return longest
+	}
+
+	subjectSeparatorLength := func() int {
+		longest := len(subjectColTitle)
+		for _, cert := range certChain {
+			if len(cert.Subject.CommonName) > longest {
+				longest = len(cert.Subject.CommonName)
+			}
+		}
+
+		return longest
+	}
+
+	issuerCertificateURLsLength := func() int {
+		longest := len(issuerCertificateURLsTitle)
+		for _, cert := range certChain {
+			for _, aiaURL := range cert.IssuingCertificateURL {
+				if len(aiaURL)+2 > longest {
+					longest = len(aiaURL) + 2
+				}
+			}
+		}
+
+		return longest
+	}
+
+	headerRowTmpl := fmt.Sprintf("%s\t%s\t%s\t%s\t",
+		certChainPositionColTitle,
+		certTypeColTitle,
+		subjectColTitle,
+		issuerCertificateURLsTitle,
+	)
+
+	separatorRowTmpl := fmt.Sprintf(
+		"%s\t%s\t%s\t%s\t",
+		strings.Repeat("-", certChainPositionSeparatorLength()),
+		strings.Repeat("-", certTypeSeparatorLength()),
+		strings.Repeat("-", subjectSeparatorLength()),
+		strings.Repeat("-", issuerCertificateURLsLength()),
+	)
+	dataRowTmpl := "%d\t%s\t%s\t%s\t\n"
+
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, headerRowTmpl)
+	_, _ = fmt.Fprintln(w, separatorRowTmpl)
+
+	for idx, cert := range certChain {
+		_, _ = fmt.Fprintf(
+			w,
+			dataRowTmpl,
+			idx,
+			certs.ChainPosition(cert, certChain),
+			cert.Subject.CommonName,
+
+			// Avoid triggering "loop variable X now per-iteration,
+			// stack-allocated" scenario by explicitly passing in the loop
+			// variable.
+			func(c *x509.Certificate) string {
+				switch {
+				case len(c.IssuingCertificateURL) == 0:
+					return "None"
+				case len(c.IssuingCertificateURL) == 1:
+					return fmt.Sprint(c.IssuingCertificateURL[0])
+				default:
+					return fmt.Sprint(c.IssuingCertificateURL)
+				}
+			}(cert),
+		)
+	}
+	_, _ = fmt.Fprintln(w)
+
+	if err := w.Flush(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/cpcert/winres/winres.json
+++ b/cmd/cpcert/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "CLI app used to copy and manipulate certs.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-cert project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "CLI app used to copy and manipulate certificates.",
+            "FileVersion": "",
+            "InternalName": "cpcert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-cert",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -63,19 +63,19 @@ func main() {
 
 	// Honor request to parse filename first
 	switch {
-	case cfg.Filename != "":
+	case cfg.InputFilename != "":
 
 		log.Debug().Msg("Attempting to retrieve certificates from file")
 
 		var err error
-		certChain, parseAttemptLeftovers, err = certs.GetCertsFromFile(cfg.Filename)
+		certChain, parseAttemptLeftovers, err = certs.GetCertsFromFile(cfg.InputFilename)
 		if err != nil {
 			log.Error().Err(err).Msg(
 				"Error parsing certificates file")
 			os.Exit(config.ExitCodeCatchall)
 		}
 
-		certChainSource = cfg.Filename
+		certChainSource = cfg.InputFilename
 
 	case cfg.Server != "":
 
@@ -216,7 +216,7 @@ func main() {
 		// was pulled from a server we "retrieved" it.
 		var template string
 		switch {
-		case cfg.Filename != "":
+		case cfg.InputFilename != "":
 			template = "- %s: %d certs found in %s\n"
 		default:
 			template = "- %s: %d certs retrieved for %s\n"
@@ -409,10 +409,11 @@ func main() {
 	if len(parseAttemptLeftovers) > 0 {
 		textutils.PrintHeader("CERTIFICATES | UNKNOWN data in cert file")
 
-		fmt.Printf("The following data (converted to text) was found in the %q file"+
-			" and is provided here in case it is useful for"+
-			" troubleshooting purposes.\n\n",
-			cfg.Filename,
+		fmt.Printf(
+			"The following data (converted to text) was found in the %q input"+
+				" file and is provided here in case it is useful for"+
+				" troubleshooting purposes.\n\n",
+			cfg.InputFilename,
 		)
 
 		fmt.Println(string(parseAttemptLeftovers))

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -577,6 +577,21 @@ func ParsePEMCertificates(pemData []byte) ([]*x509.Certificate, []byte, error) {
 	return certChain, parseAttemptLeftovers, nil
 }
 
+// WriteCertToPEMFile writes a single certificate to a file in PEM format.
+func WriteCertToPEMFile(file *os.File, cert *x509.Certificate) error {
+	pemBlock := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	}
+
+	err := pem.Encode(file, pemBlock)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // IsExpiredCert receives a x509 certificate and returns a boolean value
 // indicating whether the cert has expired.
 func IsExpiredCert(cert *x509.Certificate) bool {

--- a/internal/config/args.go
+++ b/internal/config/args.go
@@ -8,20 +8,86 @@
 package config
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
 )
+
+func (c *Config) validatePositionalArgs(appType AppType) error {
+	switch {
+	case appType.Plugin:
+
+		// placeholder
+
+	case appType.Inspector:
+
+		// placeholder
+
+	case appType.Copier:
+
+		switch {
+		// User opted to use positional argument for INPUT_PATTERN and one of
+		// the associated flags for that value.
+		case (c.InputFilename != "" || c.Server != "") && flag.Arg(0) != "":
+			return fmt.Errorf(
+				"one of %q or %q flags may be specified"+
+					" OR one of filename, URL, FQDN or hostname provided"+
+					" via first positional argument: %w",
+				ServerFlagLong,
+				InputFilenameFlagLong,
+				ErrUnsupportedOption,
+			)
+
+		// User opted to use positional argument for OUTPUT_PATTERN and the
+		// associated flag for that value.
+		case c.OutputFilename != "" && flag.Arg(1) != "":
+			return fmt.Errorf(
+				"output filename may only be specified via one of %q flag "+
+					"OR second positional argument: %w",
+				OutputFilenameFlagLong,
+				ErrUnsupportedOption,
+			)
+
+		case c.OutputFilename == "" && flag.Arg(1) == "":
+			return fmt.Errorf(
+				"output filename is required via %q flag "+
+					"OR second positional argument: %w",
+				OutputFilenameFlagLong,
+				ErrUnsupportedOption,
+			)
+
+		}
+
+	case appType.Scanner:
+
+		// placeholder
+
+	}
+
+	// Shared positional argument handling for all application types goes
+	// here.
+
+	return nil
+}
 
 // handlePositionalArgs handles any positional arguments remaining after flags
 // have been parsed. This behavior is controlled via the specified application
 // type as set by each cmd. Based on the application type, a specific set of
-// positional arguments are evaluated and potentially used to override default
-// values for defined flags.
+// positional arguments are evaluated.
+//
+// Responsibility for validating flags and positional arguments is shared
+// between this helper function and the validate method.
 func (c *Config) handlePositionalArgs(appType AppType) error {
 
 	// fmt.Println("Evaluating positional arguments ...")
 	// fmt.Println("flag.Arg(0):", flag.Arg(0))
 	// fmt.Println("flag.Args():", flag.Args())
+
+	if err := c.validatePositionalArgs(appType); err != nil {
+		return err
+	}
 
 	switch {
 	case appType.Plugin:
@@ -38,7 +104,7 @@ func (c *Config) handlePositionalArgs(appType AppType) error {
 		// This prevents overwriting any values already specified by flags in
 		// order to provide the documented behavior for specified flags and
 		// the URL pattern positional argument.
-		if flag.Arg(0) != "" && c.Server == "" && c.Filename == "" {
+		if flag.Arg(0) != "" && c.Server == "" && c.InputFilename == "" {
 			err := c.parseServerValue(flag.Arg(0))
 			if err != nil {
 				return fmt.Errorf(
@@ -46,6 +112,39 @@ func (c *Config) handlePositionalArgs(appType AppType) error {
 					err,
 				)
 			}
+		}
+
+	case appType.Copier:
+
+		// If flag.Arg(0) for INPUT_PATTERN is non-empty, then flag parsing
+		// has already been applied and a positional argument is available for
+		// evaluation.
+		if flag.Arg(0) != "" {
+			c.PosArgInputPattern = flag.Arg(0)
+
+			cleanPath := filepath.Clean(flag.Arg(0))
+
+			if _, err := os.Stat(cleanPath); err == nil {
+				c.InputFilename = cleanPath
+			} else if errors.Is(err, os.ErrNotExist) {
+				err := c.parseServerValue(flag.Arg(0))
+				if err != nil {
+					// While we check for it, parsing is *very* liberal and
+					// unlikely to trigger an error condition.
+					return fmt.Errorf(
+						"error parsing input pattern as server value or filename: %w",
+						ErrInvalidPosArgPattern,
+					)
+				}
+			}
+		}
+
+		// If flag.Arg(1) for OUTPUT_FILE is non-empty, then flag parsing has
+		// already been applied and a second positional argument is available
+		// for evaluation.
+		if flag.Arg(1) != "" {
+			c.PosArgOutputPattern = flag.Arg(1)
+			c.OutputFilename = c.PosArgOutputPattern
 		}
 
 	case appType.Scanner:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,9 +23,18 @@ import (
 // builds.
 var version = "x.y.z"
 
-// ErrVersionRequested indicates that the user requested application version
-// information.
-var ErrVersionRequested = errors.New("version information requested")
+var (
+	// ErrVersionRequested indicates that the user requested application
+	// version information.
+	ErrVersionRequested = errors.New("version information requested")
+
+	// ErrInvalidPosArgPattern indicates that the user provided an invalid
+	// pattern for a positional argument.
+	ErrInvalidPosArgPattern = errors.New("invalid positional argument pattern")
+
+	// ErrUnsupportedOption indicates that an unsupported option was specified.
+	ErrUnsupportedOption = errors.New("unsupported option")
+)
 
 // AppType represents the type of application that is being
 // configured/initialized. Not all application types will use the same
@@ -47,6 +56,10 @@ type AppType struct {
 	// intended for examining a small set of targets for
 	// informational/troubleshooting purposes.
 	Inspector bool
+
+	// Copier represents an application used for copying or manipulating
+	// certificates.
+	Copier bool
 }
 
 // multiValueStringFlag is a custom type that satisfies the flag.Value
@@ -202,17 +215,35 @@ type Config struct {
 	// comma-separated list.
 	SANsEntries multiValueStringFlag
 
-	// Filename is the fully-qualified path to a file containing one or more
-	// certificates.
-	Filename string
+	// InputFilename is the fully-qualified path to an input file containing
+	// one or more certificates.
+	InputFilename string
 
-	// Server is the fully-qualified domain name of the system running a
-	// certificate-enabled service.
+	// OutputFilename is the fully-qualified path to an output file where one
+	// or more certificates will be written.
+	OutputFilename string
+
+	// Server is the fully-qualified domain name or IP Address of the system
+	// running a certificate-enabled service.
 	Server string
+
+	// PosArgInputPattern is either the fully-qualified domain name or IP
+	// Address of the system running a certificate-enabled service or the
+	// fully-qualified path to an input file containing one or more
+	// certificates.
+	PosArgInputPattern string
+
+	// PosArgOutputPattern is the fully-qualified path to an output file where
+	// one or more certificates will be written.
+	PosArgOutputPattern string
 
 	// hosts is the list of IP Addresses (single and ranges), hostnames or
 	// FQDNs to scan for certs.
 	hosts multiValueHostsFlag
+
+	// certTypesToKeep is the list of certificate types to keep from a given
+	// input certificate chain.
+	certTypesToKeep multiValueStringFlag
 
 	// ScanRateLimit is the maximum number of concurrent port scan attempts.
 	ScanRateLimit int

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -23,6 +23,7 @@ const SkipSANSCheckKeyword string = "SKIPSANSCHECKS"
 // See https://tldp.org/LDP/abs/html/exitcodes.html for additional details.
 const ExitCodeCatchall int = 1
 
+// Flag help text.
 const (
 	versionFlagHelp                                          string = "Whether to display application version and then immediately exit application."
 	sansEntriesFlagHelp                                      string = "One or many names required to be in the Subject Alternate Names (SANs) list for a leaf certificate. If provided, this list of comma-separated values is required for the certificate to pass validation. If the case-insensitive " + SkipSANSCheckKeyword + " keyword is provided the results from this validation check will be flagged as ignored."
@@ -37,7 +38,7 @@ const (
 	timeoutAppInactivityFlagHelp                             string = "The number of seconds the application is allowed to remain inactive (i.e., \"hung\") before it is automatically terminated."
 	scanRateLimitFlagHelp                                    string = "Maximum concurrent port and certificate scans. Remaining scans are queued until an existing scan completes."
 	emitCertTextFlagHelp                                     string = "Toggles emission of x509 TLS certificates in an OpenSSL-inspired text format. This output is disabled by default."
-	filenameFlagHelp                                         string = "Fully-qualified path to a PEM formatted certificate file containing one or more certificates."
+	inputFilenameFlagHelp                                    string = "Fully-qualified path to a PEM (text) or binary DER formatted input file containing one or more certificates."
 	certExpireAgeWarningFlagHelp                             string = "The number of days remaining before certificate expiration when this application will will flag the NotAfter certificate field as a WARNING state."
 	certExpireAgeCriticalFlagHelp                            string = "The number of days remaining before certificate expiration when this application will will flag the NotAfter certificate field as a CRITICAL state."
 	brandingFlagHelp                                         string = "Toggles emission of branding details with plugin status details. This output is disabled by default."
@@ -55,6 +56,12 @@ const (
 	ignoreExpiredRootCertificatesFlagHelp                    string = "Whether expired root certificates should be ignored."
 	ignoreExpiringIntermediateCertificatesFlagHelp           string = "Whether expiring intermediate certificates should be ignored."
 	ignoreExpiringRootCertificatesFlagHelp                   string = "Whether expiring root certificates should be ignored."
+)
+
+// Flag help text specific to the Copier app type.
+const (
+	outputFilenameFlagHelp  string = "Fully-qualified path to an output file to write one or more PEM (text) encoded certificates."
+	certTypesToKeepFlagHelp string = "List of keywords for certificate types that should be kept from the input certificate chain when saving the output file."
 )
 
 // shorthandFlagSuffix is appended to short flag help text to emphasize that
@@ -95,7 +102,12 @@ const (
 	ApplyValidationResultFlag  string = "apply-validation-result"
 
 	ListIgnoredErrorsFlag             string = "list-ignored-errors"
-	FilenameFlagLong                  string = "filename"
+	FilenameFlagLong                  string = "filename"        // inspector, plugin; potentially deprecated
+	InputFilenameFlagLong             string = "input-filename"  // copier
+	InputFilenameFlagShort            string = "if"              // copier
+	OutputFilenameFlagShort           string = "of"              // copier
+	OutputFilenameFlagLong            string = "output-filename" // copier
+	CertTypesToKeepFlagLong           string = "keep"            // copier
 	EmitCertTextFlagLong              string = "text"
 	TimeoutFlagLong                   string = "timeout"
 	TimeoutFlagShort                  string = "t"
@@ -139,6 +151,15 @@ const (
 	ValidationKeywordSANsList   string = "sans"
 )
 
+// Certificate type keywords used when filtering specific certificate types
+// for the output file.
+const (
+	CertTypeAll          string = "all"
+	CertTypeLeaf         string = "leaf"
+	CertTypeIntermediate string = "intermediate"
+	CertTypeRoot         string = "root"
+)
+
 // Default flag settings if not overridden by user input
 const (
 	defaultLogLevel              string = "info"
@@ -146,7 +167,7 @@ const (
 	defaultDNSName               string = ""
 	defaultPort                  int    = 443
 	defaultEmitCertText          bool   = false
-	defaultFilename              string = ""
+	defaultFilename              string = "" // inspector, plugin; potentially deprecated
 	defaultBranding              bool   = false
 	defaultVerboseOutput         bool   = false
 	defaultDisplayVersionAndExit bool   = false
@@ -206,6 +227,13 @@ const (
 	defaultApplyCertSANsListValidationResults bool = true
 )
 
+// Constants specific to the copier app.
+const (
+	defaultCertTypesToKeep string = "all"
+	defaultInputFilename   string = "" // future: shared by all apps reading an input file
+	defaultOutputFilename  string = ""
+)
+
 // Constants specific to certsum.
 const (
 	// Default timeout (in milliseconds) used when testing whether a TCP port
@@ -252,6 +280,7 @@ const (
 const (
 	appTypePlugin    string = "plugin"
 	appTypeInspector string = "inspector"
+	appTypeCopier    string = "copier"
 	appTypeScanner   string = "scanner"
 )
 

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -57,6 +57,17 @@ func (c Config) Hosts() []netutils.HostPattern {
 	return []netutils.HostPattern{}
 }
 
+// CertTypesToKeep returns the user-specified list of certificate types to
+// keep when copying a given certificates chain or the default value if not
+// specified.
+func (c Config) CertTypesToKeep() []string {
+	if c.certTypesToKeep != nil {
+		return c.certTypesToKeep
+	}
+
+	return []string{defaultCertTypesToKeep}
+}
+
 // ApplyCertHostnameValidationResults indicates whether certificate hostname
 // validation check results should be applied when performing final plugin
 // state evaluation. Precedence is given for explicit request to ignore this
@@ -174,6 +185,17 @@ func supportedValidationCheckResultKeywords() []string {
 		ValidationKeywordHostname,
 		ValidationKeywordExpiration,
 		ValidationKeywordSANsList,
+	}
+}
+
+// supportedCertTypeFilterKeywords returns a list of valid certificate type
+// keywords used by copier type applications in this project.
+func supportedCertTypeFilterKeywords() []string {
+	return []string{
+		CertTypeAll,
+		CertTypeLeaf,
+		CertTypeIntermediate,
+		CertTypeRoot,
 	}
 }
 

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -89,12 +89,34 @@ func (c *Config) setupLogging(appType AppType) error {
 			Str("version", Version()).
 			Str("logging_level", c.LoggingLevel).
 			Str("app_type", appTypeInspector).
-			Str("filename", c.Filename).
+			Str("filename", c.InputFilename).
 			Str("server", c.Server).
 			Int("port", c.Port).
 			Str("cert_check_timeout", c.Timeout().String()).
 			Int("age_warning", c.AgeWarning).
 			Int("age_critical", c.AgeCritical).
+			Logger()
+
+	case appType.Copier:
+		// CLI app logging uses ConsoleWriter to generate human-friendly,
+		// colorized output to stdout.
+		consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout}
+
+		certTypesToKeep := zerolog.Arr()
+		for _, certType := range c.certTypesToKeep {
+			certTypesToKeep.Str(certType)
+		}
+
+		c.Log = zerolog.New(consoleWriter).With().Timestamp().Caller().
+			Str("version", Version()).
+			Str("logging_level", c.LoggingLevel).
+			Str("app_type", appTypeCopier).
+			Str("input_filename", c.InputFilename).
+			Str("output_filename", c.OutputFilename).
+			Array("cert_types_to_keep", certTypesToKeep).
+			Str("server", c.Server).
+			Int("port", c.Port).
+			Str("cert_fetch_timeout", c.Timeout().String()).
 			Logger()
 
 	case appType.Plugin:
@@ -106,7 +128,7 @@ func (c *Config) setupLogging(appType AppType) error {
 			Str("version", Version()).
 			Str("logging_level", c.LoggingLevel).
 			Str("app_type", appTypePlugin).
-			Str("filename", c.Filename).
+			Str("filename", c.InputFilename).
 			Str("server", c.Server).
 			Int("port", c.Port).
 			Str("cert_check_timeout", c.Timeout().String()).

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -16,10 +16,6 @@ import (
 
 // parseServerValue evaluates a given string as a potential URL.
 //
-// If the given string does not fail parsing, but is not found to be a valid
-// URL the given string is assigned directly to the Config.Server field as-is
-// for later evaluation.
-//
 // If matched, the parsed host value is used to populate the Config.Server
 // field and the parsed port value (if available) is used to populate the
 // Config.Port field.
@@ -27,6 +23,10 @@ import (
 // The caller is responsible for guarding against overwriting any values
 // already specified by flags in order to provide the documented behavior for
 // specified flags and the URL pattern positional argument.
+//
+// If the given string does not fail parsing, but is not found to be a valid
+// URL or hostname the input string is used as-is to populate the
+// Config.Server field.
 func (c *Config) parseServerValue(serverVal string) error {
 
 	// url.Parse() is very forgiving. All known "valid" values are
@@ -96,9 +96,10 @@ func (c *Config) parseServerValue(serverVal string) error {
 		}
 
 	// If the specified server value was successfully parsed as a URL without
-	// a hostname value (in which case the server value is treated as a
-	// relative URL) we record the specified server value as-is for later
-	// validation.
+	// a hostname value then we record the specified server value as-is
+	// instead of using the parsed result; the specified server value may be a
+	// valid short name, fully-qualified domain name or IP Address of a system
+	// to evaluate.
 	default:
 
 		c.Server = serverVal

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -14,16 +14,61 @@ import (
 	"github.com/atc0005/check-cert/internal/textutils"
 )
 
-// validate verifies all Config struct fields have been provided acceptable
-// values.
+func validateAgeThresholds(c Config) error {
+	switch {
+	case c.AgeWarning < 1:
+		return fmt.Errorf(
+			"invalid cert expiration WARNING threshold number: %d",
+			c.AgeWarning,
+		)
+
+	case c.AgeCritical < 1:
+		return fmt.Errorf(
+			"invalid cert expiration CRITICAL threshold number: %d",
+			c.AgeCritical,
+		)
+
+	case c.AgeCritical > c.AgeWarning:
+		return fmt.Errorf(
+			"critical threshold set higher than warning threshold",
+		)
+
+	case c.AgeCritical == c.AgeWarning:
+		return fmt.Errorf(
+			"critical threshold set equal to warning threshold",
+		)
+
+	default:
+		return nil
+	}
+}
+
+func validatePort(c Config) error {
+	// TCP Port 0 is used by server applications to indicate that they
+	// should bind to an available port. Specifying port 0 for a client
+	// application is not useful.
+	if c.Port <= 0 {
+		return fmt.Errorf(
+			"invalid TCP port number; got %d,"+
+				" expected value between %d and %d (e.g., 443, 636)",
+			c.Port,
+			tcpSystemPortStart,
+			tcpDynamicPrivatePortEnd,
+		)
+	}
+
+	return nil
+}
+
+// validate verifies all Config struct fields have been set to an acceptable
+// state. Positional argument handling AND validation is handled earlier in
+// the configuration initialization process.
 func (c Config) validate(appType AppType) error {
 
 	switch {
 	case appType.Inspector:
-		// User can specify one of filename or server, but not both (mostly in
-		// order to keep the logic simpler)
 		switch {
-		case c.Filename == "" && c.Server == "":
+		case c.InputFilename == "" && c.Server == "":
 			return fmt.Errorf(
 				"one of %q or %q flags must be specified"+
 					" or one of URL, FQDN or hostname provided"+
@@ -31,7 +76,7 @@ func (c Config) validate(appType AppType) error {
 				ServerFlagLong,
 				FilenameFlagLong,
 			)
-		case c.Filename != "" && c.Server != "":
+		case c.InputFilename != "" && c.Server != "":
 			return fmt.Errorf(
 				"only one of %q or %q flags may be specified",
 				ServerFlagLong,
@@ -39,30 +84,85 @@ func (c Config) validate(appType AppType) error {
 			)
 		}
 
-		// TCP Port 0 is used by server applications to indicate that they should
-		// bind to an available port. Specifying port 0 for a client application
-		// is not useful.
-		if c.Port <= 0 {
+		if err := validatePort(c); err != nil {
+			return err
+		}
+
+		if err := validateAgeThresholds(c); err != nil {
+			return err
+		}
+
+	case appType.Copier:
+
+		// User can specify one of input filename or server, but not both.
+		if c.InputFilename != "" && c.Server != "" {
 			return fmt.Errorf(
-				"invalid TCP port number; got %d,"+
-					" expected value between %d and %d (e.g., 443, 636)",
-				c.Port,
-				tcpSystemPortStart,
-				tcpDynamicPrivatePortEnd,
+				"only one of %q OR %q flags may be specified: %w",
+				ServerFlagLong,
+				InputFilenameFlagLong,
+				ErrUnsupportedOption,
 			)
 		}
 
+		// NOTE:
+		//
+		// Checking for conflicts between positional arguments and equivalent
+		// flags is currently handled by the handlePositionalArgs method and
+		// any helper logic it may call.
+
+		if err := validatePort(c); err != nil {
+			return err
+		}
+
+		// Assert that only supported keywords are specified.
+		supportedCertTypeFilterKeywords := supportedCertTypeFilterKeywords()
+		for _, specifiedKeyword := range c.certTypesToKeep {
+			if !textutils.InList(specifiedKeyword, supportedCertTypeFilterKeywords, true) {
+				return fmt.Errorf(
+					"invalid cert type filter keyword specified; got %v, "+
+						"expected one of %v: %w",
+					specifiedKeyword,
+					supportedCertTypeFilterKeywords,
+					ErrUnsupportedOption,
+				)
+			}
+		}
+
+		// Assert that only valid combinations of keywords are specified; if
+		// CertTypeAll is specified no other (normally valid) keywords from
+		// that set are permitted.
+		if textutils.InList(CertTypeAll, c.certTypesToKeep, true) {
+			if len(c.certTypesToKeep) > 1 {
+				otherValidVals := func() []string {
+					vals := make([]string, 0, len(supportedCertTypeFilterKeywords))
+					for _, val := range supportedCertTypeFilterKeywords {
+						if val != CertTypeAll {
+							vals = append(vals, val)
+						}
+					}
+					return vals
+				}()
+
+				return fmt.Errorf(
+					"invalid keywords combination; got %v, "+
+						"expected just %q or one of %v: %w",
+					c.certTypesToKeep,
+					CertTypeAll,
+					otherValidVals,
+					ErrUnsupportedOption,
+				)
+			}
+		}
+
 	case appType.Plugin:
-		// User can specify one of filename or server, but not both (mostly in
-		// order to keep the logic simpler)
 		switch {
-		case c.Filename == "" && c.Server == "":
+		case c.InputFilename == "" && c.Server == "":
 			return fmt.Errorf(
 				"one of %q or %q flags must be specified",
 				ServerFlagLong,
 				FilenameFlagLong,
 			)
-		case c.Filename != "" && c.Server != "":
+		case c.InputFilename != "" && c.Server != "":
 			return fmt.Errorf(
 				"only one of %q or %q flags may be specified; if evaluating"+
 					" certificate files use the %q flag instead of the %q"+
@@ -77,17 +177,8 @@ func (c Config) validate(appType AppType) error {
 			)
 		}
 
-		// TCP Port 0 is used by server applications to indicate that they should
-		// bind to an available port. Specifying port 0 for a client application
-		// is not useful.
-		if c.Port <= 0 {
-			return fmt.Errorf(
-				"invalid TCP port number; got %d,"+
-					" expected value between %d and %d (e.g., 443, 636)",
-				c.Port,
-				tcpSystemPortStart,
-				tcpDynamicPrivatePortEnd,
-			)
+		if err := validatePort(c); err != nil {
+			return err
 		}
 
 		supportedValidationKeywords := supportedValidationCheckResultKeywords()
@@ -156,6 +247,10 @@ func (c Config) validate(appType AppType) error {
 			}
 		}
 
+		if err := validateAgeThresholds(c); err != nil {
+			return err
+		}
+
 	case appType.Scanner:
 
 		// Use getter method in order to validate final ports list. Because we
@@ -212,38 +307,16 @@ func (c Config) validate(appType AppType) error {
 			return fmt.Errorf("host values (one or many, single or IP Address ranges) not provided")
 		}
 
+		if err := validateAgeThresholds(c); err != nil {
+			return err
+		}
+
 		// TODO: Figure out how to (or if we need to) validate mix of boolean
 		// value "show" flags
 	}
 
 	if c.Timeout() < 0 {
 		return fmt.Errorf("invalid timeout value %d provided", c.Timeout())
-	}
-
-	if c.AgeWarning < 1 {
-		return fmt.Errorf(
-			"invalid cert expiration WARNING threshold number: %d",
-			c.AgeWarning,
-		)
-	}
-
-	if c.AgeCritical < 1 {
-		return fmt.Errorf(
-			"invalid cert expiration CRITICAL threshold number: %d",
-			c.AgeCritical,
-		)
-	}
-
-	if c.AgeCritical > c.AgeWarning {
-		return fmt.Errorf(
-			"critical threshold set higher than warning threshold",
-		)
-	}
-
-	if c.AgeCritical == c.AgeWarning {
-		return fmt.Errorf(
-			"critical threshold set equal to warning threshold",
-		)
 	}
 
 	// Validate the specified logging level

--- a/packages/dev/nfpm.yaml
+++ b/packages/dev/nfpm.yaml
@@ -37,6 +37,11 @@ contents:
     file_info:
       mode: 0755
 
+  - src: ../../release_assets/cpcert/cpcert-linux-amd64-dev
+    dst: /usr/bin/cpcert_dev
+    file_info:
+      mode: 0755
+
   - src: ../../release_assets/check_cert/check_cert-linux-amd64-dev
     dst: /usr/lib64/nagios/plugins/check_cert_dev
     file_info:

--- a/packages/stable/nfpm.yaml
+++ b/packages/stable/nfpm.yaml
@@ -37,6 +37,11 @@ contents:
     file_info:
       mode: 0755
 
+  - src: ../../release_assets/cpcert/cpcert-linux-amd64
+    dst: /usr/bin/cpcert
+    file_info:
+      mode: 0755
+
   - src: ../../release_assets/check_cert/check_cert-linux-amd64
     dst: /usr/lib64/nagios/plugins/check_cert
     file_info:


### PR DESCRIPTION
## Changes

The new `cpcert` prototype tool supports copying certificate chains from a server or input file and optionally filtering to specific certificate types before saving to an output file (PEM format).

Config validation logic has been refactored to help the new tool fit within the project without duplicating existing work.

Overall, this is a "MVP" build and while usable, it should be considered to be of "alpha" level quality. Please report issues that you encounter.

Many of the exposed flags, help text and summary output are subject to change significantly in later releases.

Feedback on the new `cpcert` tool is welcome:

- https://github.com/atc0005/check-cert/discussions/963

## References

- fixes GH-171
- fixes GH-956