### PR TITLE
Update `lscert` hostname validation behavior

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -616,6 +616,43 @@ func IsExpiringCert(cert *x509.Certificate, ageCritical time.Time, ageWarning ti
 
 }
 
+// HasLeafCert receives a slice of x509 certificates and indicates whether
+// any of the certificates in the chain are a leaf certificate.
+func HasLeafCert(certChain []*x509.Certificate) bool {
+	for _, cert := range certChain {
+		if IsLeafCert(cert, certChain) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// HasIntermediateCert receives a slice of x509 certificates and indicates
+// whether any of the certificates in the chain are an intermediate
+// certificate.
+func HasIntermediateCert(certChain []*x509.Certificate) bool {
+	for _, cert := range certChain {
+		if IsIntermediateCert(cert, certChain) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// HasRootCert receives a slice of x509 certificates and indicates whether any
+// of the certificates in the chain are a root certificate.
+func HasRootCert(certChain []*x509.Certificate) bool {
+	for _, cert := range certChain {
+		if IsRootCert(cert, certChain) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // HasExpiredCert receives a slice of x509 certificates and indicates whether
 // any of the certificates in the chain have expired.
 func HasExpiredCert(certChain []*x509.Certificate) bool {


### PR DESCRIPTION
## Changes

Update hostname validation logic to ignore the result if a leaf certificate is not present in the given certificate chain OR if the `dns-name` flag was not used. Add a slight addendum/note explaining what is needed (if a leaf cert is present) or that the check is unsupported (if no leaf cert is present).

Add new functions to the `internal/certs` package to quickly answer whether any certificate of the specified type is present within a given certificate chain:

- `HasLeafCert`
- `HasIntermediateCert`
- `HasRootCert`

## References

- fixes GH-952