### PR TITLE
Add SANs entries count to cert metadata payload

### DIFF
--- a/cmd/check_cert/paypload.go
+++ b/cmd/check_cert/paypload.go
@@ -214,6 +214,7 @@ func buildCertSummary(cfg *config.Config, validationResults certs.CertChainValid
 			Subject:                   origCert.Subject.String(),
 			CommonName:                origCert.Subject.CommonName,
 			SANsEntries:               SANsEntries,
+			SANsEntriesCount:          len(SANsEntries),
 			Issuer:                    origCert.Issuer.String(),
 			IssuerShort:               origCert.Issuer.CommonName,
 			SerialNumber:              certs.FormatCertSerialNumber(origCert.SerialNumber),


### PR DESCRIPTION
This field would allow the sysadmin to omit the full list of SANs entries to conserve plugin output size and still indicate the number of SANs entries present for a certificate. This helps prevent a scenario where an empty SANs entries collection implies that no SANs entries were provided (though the `CertificateChainIssues.MissingSANsEntries` field if checked would dispel that notion) but also provides the number for use in display or for metrics purposes.

fixes GH-1045