### PR TITLE
Add Cert Signature Algorithm to cert payload

### DIFF
--- a/cmd/check_cert/paypload.go
+++ b/cmd/check_cert/paypload.go
@@ -227,6 +227,7 @@ func buildCertSummary(cfg *config.Config, validationResults certs.CertChainValid
 			ValidityPeriodDays:        certExpMeta.validityPeriodDays,
 			Summary:                   expiresText,
 			Status:                    certStatus,
+			SignatureAlgorithm:        origCert.SignatureAlgorithm.String(),
 			Type:                      certs.ChainPosition(origCert, certChain),
 		}
 


### PR DESCRIPTION
This field will be used to report what algorithm was used to sign a certificate. Weak signature algorithms are considered a vulnerability for remediation, so surfacing this value is useful for reporting (and other) purposes.

refs GH-1044