### PR TITLE
Rework listing root cert sig algorithm as ignored

### DIFF
--- a/cmd/check_cert/paypload.go
+++ b/cmd/check_cert/paypload.go
@@ -336,7 +336,7 @@ func buildCertSummary(cfg *config.Config, validationResults certs.CertChainValid
 			// case chainPos == "root":
 			// 	logIgnored(cert)
 
-			case certs.HasWeakSignatureAlgorithm(cert, certChain):
+			case certs.HasWeakSignatureAlgorithm(cert, certChain, false):
 				logWeak(cert)
 
 				return true


### PR DESCRIPTION
Refactor logic to allow "helper" functions to optionally evaluate (but ignore by default), explicitly note when weak signature is detected but ignored.

refs GH-1063