### PR TITLE
Fix SANs entries count payload field logic

### DIFF
--- a/cmd/check_cert/paypload.go
+++ b/cmd/check_cert/paypload.go
@@ -216,7 +216,7 @@ func buildCertSummary(cfg *config.Config, validationResults certs.CertChainValid
 			Subject:                   origCert.Subject.String(),
 			CommonName:                origCert.Subject.CommonName,
 			SANsEntries:               SANsEntries,
-			SANsEntriesCount:          len(SANsEntries),
+			SANsEntriesCount:          len(origCert.DNSNames),
 			Issuer:                    origCert.Issuer.String(),
 			IssuerShort:               origCert.Issuer.CommonName,
 			SerialNumber:              certs.FormatCertSerialNumber(origCert.SerialNumber),


### PR DESCRIPTION
Base count on original certificate SANs list and not potentially empty list (if sysadmin opts to skip including them in the output).

refs GH-1045