### PR TITLE
Fix error handling for cert payload generation

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -425,19 +425,21 @@ func main() {
 
 	if cfg.EmitPayload || cfg.EmitPayloadWithFullChain {
 		payloadErr := addCertChainPayload(plugin, cfg, validationResults)
-		log.Error().
-			Err(payloadErr).
-			Msg("failed to add encoded payload")
+		if payloadErr != nil {
+			log.Error().
+				Err(payloadErr).
+				Msg("failed to add encoded payload")
 
-		plugin.Errors = append(plugin.Errors, payloadErr)
+			plugin.Errors = append(plugin.Errors, payloadErr)
 
-		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
-		plugin.ServiceOutput = fmt.Sprintf(
-			"%s: Failed to add encoded payload",
-			nagios.StateUNKNOWNLabel,
-		)
+			plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+			plugin.ServiceOutput = fmt.Sprintf(
+				"%s: Failed to add encoded payload",
+				nagios.StateUNKNOWNLabel,
+			)
 
-		return
+			return
+		}
 	}
 
 	switch {


### PR DESCRIPTION
Add missing `if err != nil` check intended for inclusion with 98d62222cd92e1807237f0cf281d3172a4a5c4bd. This is what I get for multitasking.