### PR TITLE
Fix errwrap linting error

### DIFF
--- a/internal/netutils/net.go
+++ b/internal/netutils/net.go
@@ -587,10 +587,10 @@ func ExpandHost(hostPattern string) (HostPattern, error) {
 		ipAddrs, lookupErr := net.LookupHost(hostPattern)
 		if lookupErr != nil {
 			return HostPattern{}, fmt.Errorf(
-				"%q invalid; %w: %s",
+				"%q invalid; %w: %w",
 				hostPattern,
 				ErrHostnameFailsNameResolution,
-				lookupErr.Error(),
+				lookupErr,
 			)
 		}
 


### PR DESCRIPTION
Replace explicit Error() method call on lookup error to switch from returning a string suffix to including an additional error by way of a second error wrapping verb (Go 1.20+).

fixes GH-564