### PR TITLE
Enable plugin output size metric

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -27,6 +27,8 @@ func main() {
 
 	plugin := nagios.NewPlugin()
 
+	plugin.EnablePluginOutputSizePerfDataMetric()
+
 	// Override default section headers with our custom values.
 	plugin.SetErrorsLabel("VALIDATION ERRORS")
 	plugin.SetDetailedInfoLabel("VALIDATION CHECKS REPORT")

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/atc0005/cert-payload v0.7.0-alpha.3
-	github.com/atc0005/go-nagios v0.18.1
+	github.com/atc0005/go-nagios v0.19.0-alpha.1
 	github.com/grantae/certinfo v0.0.0-20170412194111-59d56a35515b
 	github.com/rs/zerolog v1.33.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/atc0005/cert-payload v0.7.0-alpha.3 h1:mnBoCxbx48OP0840g+CvsfpT2OGZVBCT2Tg0WCr35Ho=
 github.com/atc0005/cert-payload v0.7.0-alpha.3/go.mod h1:zgKxu51OfQJvWRgBCdMk4b/LMotprdFeidietjopVgY=
-github.com/atc0005/go-nagios v0.18.1 h1:YGYNTyjNJiGXcCXYMhatHKzddjij06Peeb0va/wX45g=
-github.com/atc0005/go-nagios v0.18.1/go.mod h1:n2RHhsrgI8xiapqkJ240dKLwMXWbWvkOPLE92x0IGaM=
+github.com/atc0005/go-nagios v0.19.0-alpha.1 h1:j06uEubgiOfdHV/UA2Z5cLsEcZ34MbxrN3fTNjFfcfM=
+github.com/atc0005/go-nagios v0.19.0-alpha.1/go.mod h1:7XhhQHYOD+jZQVrTWXuWzSoPoDb6/FQh60dbGauQ5lQ=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -19,7 +19,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/vendor/github.com/atc0005/go-nagios/CHANGELOG.md
+++ b/vendor/github.com/atc0005/go-nagios/CHANGELOG.md
@@ -26,71 +26,6 @@ The following types of changes will be recorded in this file:
 
 - placeholder
 
-## [v0.18.1] - 2024-11-23
-
-### Changed
-
-- (GH-317) Extend logging for error collection handling
-- (GH-313) Update connectionResetByPeerAdvice doc comments
-
-### Fixed
-
-- (GH-315) Fix log message for skipping thresholds section
-
-## [v0.18.0] - 2024-11-16
-
-### Changed
-
-- (GH-309) Add support for transparent payload compression
-- (GH-300) Update `logPluginOutputSize` calls for consistency
-- (GH-310) Update README to note payload behavior changes
-
-## [v0.17.1] - 2024-11-08
-
-### Changed
-
-- (GH-296) Unescape encoded Ascii85 payload before decoding
-
-## [v0.17.0] - 2024-11-06
-
-### Added
-
-- (GH-288) Add support for embedded/encoded payloads
-- (GH-289) Add support for (internal) debug logging output
-
-### Changed
-
-- (GH-291) Clarify handling of empty payload input
-- (GH-292) Enable LongServiceOutput header/label for payloads
-
-### Fixed
-
-- (GH-268) Fix `Plugin.SetOutputTarget` method
-- (GH-273) Fix test case validity check
-- (GH-290) Minor refactoring of Range and Thresholds support
-
-## [v0.16.2] - 2024-10-10
-
-### Changed
-
-#### Dependency Updates
-
-- (GH-240) Update Dependabot PR prefixes
-- (GH-241) Update Dependabot PR prefixes (redux)
-- (GH-242) Go Dependency: Bump github.com/stretchr/testify from 1.8.4 to 1.9.0
-
-#### Other
-
-- (GH-245) Add check_cert plugin perfdata success test case
-- (GH-254) Update README reference links
-
-### Fixed
-
-- (GH-247) Remove inactive maligned linter
-- (GH-248) Fix errcheck linting errors
-- (GH-252) Fix `TestEmptyServiceOutputProducesNoOutput` test
-- (GH-257) Fix `predeclared` linter warnings
-
 ## [v0.16.1] - 2024-01-25
 
 ### Added
@@ -586,12 +521,7 @@ Initial package state
 
 - Nagios state map
 
-[Unreleased]: https://github.com/atc0005/go-nagios/compare/v0.18.1...HEAD
-[v0.18.1]: https://github.com/atc0005/go-nagios/releases/tag/v0.18.1
-[v0.18.0]: https://github.com/atc0005/go-nagios/releases/tag/v0.18.0
-[v0.17.1]: https://github.com/atc0005/go-nagios/releases/tag/v0.17.1
-[v0.17.0]: https://github.com/atc0005/go-nagios/releases/tag/v0.17.0
-[v0.16.2]: https://github.com/atc0005/go-nagios/releases/tag/v0.16.2
+[Unreleased]: https://github.com/atc0005/go-nagios/compare/v0.16.1...HEAD
 [v0.16.1]: https://github.com/atc0005/go-nagios/releases/tag/v0.16.1
 [v0.16.0]: https://github.com/atc0005/go-nagios/releases/tag/v0.16.0
 [v0.15.0]: https://github.com/atc0005/go-nagios/releases/tag/v0.15.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,7 +7,7 @@ github.com/atc0005/cert-payload/format/v1
 github.com/atc0005/cert-payload/input
 github.com/atc0005/cert-payload/internal/certs
 github.com/atc0005/cert-payload/internal/textutils
-# github.com/atc0005/go-nagios v0.18.1
+# github.com/atc0005/go-nagios v0.19.0-alpha.1
 ## explicit; go 1.19
 github.com/atc0005/go-nagios
 # github.com/grantae/certinfo v0.0.0-20170412194111-59d56a35515b


### PR DESCRIPTION
This metric is primarily used to audit current plugin output size values before enabling the generation of a certificate metadata payload (which increases the output size quite a bit).