### PR TITLE
Add ValidationStatus to CertChainValidationResult

### DIFF
--- a/internal/certs/validation-expiration.go
+++ b/internal/certs/validation-expiration.go
@@ -727,15 +727,11 @@ func (evr ExpirationValidationResult) FilteredCertificateChain() []*x509.Certifi
 // validation status value is based on the filtered chain, otherwise the
 // original certificate chain is used.
 func (evr ExpirationValidationResult) ValidationStatus() string {
-	filteredCertChain := evr.FilteredCertificateChain()
-
 	switch {
-	case HasExpiredCert(filteredCertChain):
-		return "failed"
-	case HasExpiringCert(filteredCertChain, evr.ageCriticalThreshold, evr.ageWarningThreshold):
-		return "failed"
-	case evr.ignored:
-		return "ignored"
+	case evr.IsFailed():
+		return ValidationStatusFailed
+	case evr.IsIgnored():
+		return ValidationStatusIgnored
 	default:
 		return "successful"
 	}

--- a/internal/certs/validation-hostname.go
+++ b/internal/certs/validation-hostname.go
@@ -544,3 +544,16 @@ func (hnvr HostnameValidationResult) Report() string {
 	}
 
 }
+
+// ValidationStatus provides a one word status value for hostname validation
+// check results.
+func (hnvr HostnameValidationResult) ValidationStatus() string {
+	switch {
+	case hnvr.IsFailed():
+		return ValidationStatusFailed
+	case hnvr.IsIgnored():
+		return ValidationStatusIgnored
+	default:
+		return ValidationStatusSuccessful
+	}
+}

--- a/internal/certs/validation-results.go
+++ b/internal/certs/validation-results.go
@@ -16,6 +16,14 @@ import (
 	"github.com/atc0005/go-nagios"
 )
 
+// CertChainValidationResult validation status keywords. These values provide
+// a one word status value for validation check results.
+const (
+	ValidationStatusFailed     string = "failed"
+	ValidationStatusIgnored    string = "ignored"
+	ValidationStatusSuccessful string = "successful"
+)
+
 // CertChainValidationResult represents the result for a validation check
 // associated with a certificate chain. The result can indicate success,
 // failure or if validation was ignored.
@@ -56,6 +64,10 @@ type CertChainValidationResult interface {
 	//
 	// missing: [konrad-test.amazon.com, mp3recs.amazon.com, test-www.amazon.com, www.cdn.amazon.com, www.m.amazon.com, yellowpages.amazon.com], unexpected: [origin-www.amazon.com, buckeye-retail-website.amazon.com, huddles.amazon.com]
 	StatusDetail() string
+
+	// ValidationStatus provides a one word status value for validation check
+	// results (e.g., "failed", "ignored" or "successful").
+	ValidationStatus() string
 
 	// String provides the validation result in human-readable format.
 	//

--- a/internal/certs/validation-sans.go
+++ b/internal/certs/validation-sans.go
@@ -477,3 +477,16 @@ func (slvr SANsListValidationResult) NumMismatched() int {
 	return len(slvr.unmatchedSANsEntriesFromCert) +
 		len(slvr.unmatchedSANsEntriesFromList)
 }
+
+// ValidationStatus provides a one word status value for hostname validation
+// check results.
+func (slvr SANsListValidationResult) ValidationStatus() string {
+	switch {
+	case slvr.IsFailed():
+		return ValidationStatusFailed
+	case slvr.IsIgnored():
+		return ValidationStatusIgnored
+	default:
+		return ValidationStatusSuccessful
+	}
+}


### PR DESCRIPTION
Extend the CertChainValidationResult interface to require an implementation of ValidationStatus method.

Add/Update implementation for each of:

- ExpirationValidationResult
- SANsListValidationResult
- HostnameValidationResult

Update the ExpirationValidationResult implementation to use existing helper methods to determine validation status instead of repeating expiration checks.

Add `ValidationStatus*` keyword constants for use with all CertChainValidationResult implementations.