### PR TITLE
Update atc0005/cert-payload to v0.7.1-alpha.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/atc0005/check-cert
 go 1.20
 
 require (
-	github.com/atc0005/cert-payload v0.7.0
+	github.com/atc0005/cert-payload v0.7.1-alpha.1
 	github.com/atc0005/go-nagios v0.19.0
 	github.com/grantae/certinfo v0.0.0-20170412194111-59d56a35515b
 	github.com/rs/zerolog v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/atc0005/cert-payload v0.7.0 h1:q3J8PwdzdrLDzylrw0so0XC1i+ZK7VJCRaZ8fTzuEPY=
-github.com/atc0005/cert-payload v0.7.0/go.mod h1:zgKxu51OfQJvWRgBCdMk4b/LMotprdFeidietjopVgY=
+github.com/atc0005/cert-payload v0.7.1-alpha.1 h1:5O0s1jNqv2MXzb16FUKsKVWrCmH2wZyWRoR+eFAvF28=
+github.com/atc0005/cert-payload v0.7.1-alpha.1/go.mod h1:zgKxu51OfQJvWRgBCdMk4b/LMotprdFeidietjopVgY=
 github.com/atc0005/go-nagios v0.19.0 h1:QMqu4iAKb4SD/kdAJdnMYZjHL4KzfYOSq5Lq30AZc0U=
 github.com/atc0005/go-nagios v0.19.0/go.mod h1:7XhhQHYOD+jZQVrTWXuWzSoPoDb6/FQh60dbGauQ5lQ=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/vendor/github.com/atc0005/cert-payload/CHANGELOG.md
+++ b/vendor/github.com/atc0005/cert-payload/CHANGELOG.md
@@ -26,24 +26,6 @@ The following types of changes will be recorded in this file:
 
 - placeholder
 
-## [v0.7.0] - 2024-12-03
-
-### Added
-
-- (GH-64) Add initial support for encoding/decoding cert payloads
-- (GH-65) Add Certificates collection type & initial methods
-- (GH-69) Promote v1 to stable format
-
-### Changed
-
-- (GH-67) Note why certs.MaxLifespanInDays truncates result
-
-### Fixed
-
-- (GH-45) godoc formatting tweaks
-- (GH-66) Update validity period description logic
-- (GH-68) Refactor logic to resolve linting errors
-
 ## [v0.6.1] - 2024-11-17
 
 ### Changed
@@ -92,8 +74,7 @@ Add current code used in `atc0005/check-cert` prototype to be used when
 generating an encoded certificate chain metadata payload for inclusion in
 plugin output.
 
-[Unreleased]: https://github.com/atc0005/cert-payload/compare/v0.7.0...HEAD
-[v0.7.0]: https://github.com/atc0005/cert-payload/releases/tag/v0.7.0
+[Unreleased]: https://github.com/atc0005/cert-payload/compare/v0.6.1...HEAD
 [v0.6.1]: https://github.com/atc0005/cert-payload/releases/tag/v0.6.1
 [v0.6.0]: https://github.com/atc0005/cert-payload/releases/tag/v0.6.0
 [v0.5.0]: https://github.com/atc0005/cert-payload/releases/tag/v0.5.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/atc0005/cert-payload v0.7.0
+# github.com/atc0005/cert-payload v0.7.1-alpha.1
 ## explicit; go 1.19
 github.com/atc0005/cert-payload
 github.com/atc0005/cert-payload/format/internal/shared


### PR DESCRIPTION
Pull in recent changes for testing:

- adjust misordered chain logic
- refactor self-signed signature handling

See also:

https://github.com/atc0005/cert-payload/releases/tag/v0.7.1-alpha.1