### PR TITLE
Return incomplete chain error when chain is empty

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -126,6 +126,10 @@ var (
 	// attempt between an issued certificate and an issuer certificate was
 	// unsuccessful.
 	ErrSignatureVerificationFailed = errors.New("signature verification failed")
+
+	// ErrIncompleteCertificateChain indicates that a certificate chain is
+	// missing one or more certificates (e.g., only leaf cert is present).
+	ErrIncompleteCertificateChain = errors.New("certificate chain incomplete")
 )
 
 // ServiceStater represents a type that is capable of evaluating its overall

--- a/internal/certs/validation-expiration.go
+++ b/internal/certs/validation-expiration.go
@@ -135,7 +135,7 @@ func ValidateExpiration(
 			validationOptions: validationOptions,
 			err: fmt.Errorf(
 				"required certificate chain is empty: %w",
-				ErrMissingValue,
+				ErrIncompleteCertificateChain,
 			),
 			ignored:          validationOptions.IgnoreValidationResultExpiration,
 			priorityModifier: priorityModifierMaximum,

--- a/internal/certs/validation-hostname.go
+++ b/internal/certs/validation-hostname.go
@@ -127,7 +127,7 @@ func ValidateHostname(
 			ignoreIfSANsEmptyFlagName: ignoreIfSANsEmptyFlagName,
 			err: fmt.Errorf(
 				"required certificate chain is empty: %w",
-				ErrMissingValue,
+				ErrIncompleteCertificateChain,
 			),
 			ignored:          validationOptions.IgnoreValidationResultHostname,
 			priorityModifier: priorityModifierMaximum,

--- a/internal/certs/validation-sans.go
+++ b/internal/certs/validation-sans.go
@@ -95,7 +95,7 @@ func ValidateSANsList(
 			validationOptions: validationOptions,
 			err: fmt.Errorf(
 				"required certificate chain is empty: %w",
-				ErrMissingValue,
+				ErrIncompleteCertificateChain,
 			),
 			ignored:          validationOptions.IgnoreValidationResultSANs,
 			priorityModifier: priorityModifierMaximum,


### PR DESCRIPTION
Update santity checks switch blocks for SANs, Expiration and Hostname validation to return `ErrIncompleteCertificateChain` error value when cert chain is of length 0.