### PR TITLE
Bump priority for unhandled hostname verify fail

### DIFF
--- a/internal/certs/validation-hostname.go
+++ b/internal/certs/validation-hostname.go
@@ -214,7 +214,7 @@ func ValidateHostname(
 				verifyErr,
 			),
 			ignored:          validationOptions.IgnoreValidationResultHostname,
-			priorityModifier: priorityModifierMinimum,
+			priorityModifier: priorityModifierMaximum,
 		}
 
 	// Hostname verification succeeded.


### PR DESCRIPTION
Bump from minimum to maximum to reflect how severe the issue is.

fixes GH-1152