### PR TITLE
SANs List validation early exit when list is empty

### DIFF
--- a/internal/certs/validation-sans.go
+++ b/internal/certs/validation-sans.go
@@ -106,7 +106,7 @@ func ValidateSANsList(
 	//
 	// NOTE: While configuration validation is expected to prevent this
 	// scenario we explicitly guard against it.
-	case len(requiredEntries) == 0:
+	case len(requiredEntries) == 0 && !validationOptions.IgnoreValidationResultSANs:
 		return SANsListValidationResult{
 			certChain:         certChain,
 			leafCert:          leafCert,
@@ -119,6 +119,17 @@ func ValidateSANsList(
 			priorityModifier: priorityModifierMaximum,
 		}
 
+	// If we're not given a list to process AND we are asked to ignore this,
+	// abort early.
+	case len(requiredEntries) == 0 && validationOptions.IgnoreValidationResultSANs:
+		return SANsListValidationResult{
+			certChain:         certChain,
+			leafCert:          leafCert,
+			validationOptions: validationOptions,
+			err:               nil,
+			ignored:           validationOptions.IgnoreValidationResultSANs,
+			priorityModifier:  priorityModifierBaseline,
+		}
 	}
 
 	// Assuming that the DNSNames slice is NOT already lowercase, so forcing


### PR DESCRIPTION
Exit early if no list provided and the option to ignore this validation check (default setting) is specified.