### PR TITLE
Add explicit baseline priority for check results

### DIFF
--- a/internal/certs/validation-hostname.go
+++ b/internal/certs/validation-hostname.go
@@ -231,7 +231,8 @@ func ValidateHostname(
 			//
 			// A: Yes, *if* the sysadmin explicitly requested that the result
 			// be ignored.
-			ignored: validationOptions.IgnoreValidationResultHostname,
+			ignored:          validationOptions.IgnoreValidationResultHostname,
+			priorityModifier: priorityModifierBaseline,
 		}
 
 	}

--- a/internal/certs/validation-sans.go
+++ b/internal/certs/validation-sans.go
@@ -198,6 +198,7 @@ func ValidateSANsList(
 			// be ignored.
 			ignored:          validationOptions.IgnoreValidationResultSANs,
 			requiredSANsList: requiredEntries,
+			priorityModifier: priorityModifierBaseline,
 		}
 	}
 


### PR DESCRIPTION
Changes:

- add baseline priority for successful `HostnameValidationResult`
- add baseline priority for successful `SANsListValidationResult`

This puts all three `CertChainValidationResults` implementations on equal footing.