### PR TITLE
Adjust ExpirationValidationResult priority

### DIFF
--- a/internal/certs/validation-expiration.go
+++ b/internal/certs/validation-expiration.go
@@ -268,7 +268,7 @@ func ValidateExpiration(
 			hasExpiringRootCerts:         hasExpiringRootCerts,
 			numExpiredCerts:              numExpiredCerts,
 			numExpiringCerts:             numExpiringCerts,
-			priorityModifier:             priorityModifierMinimum,
+			priorityModifier:             priorityModifierMedium,
 		}
 
 	case hasExpiringIntermediateCerts &&
@@ -295,7 +295,7 @@ func ValidateExpiration(
 			hasExpiringRootCerts:         hasExpiringRootCerts,
 			numExpiredCerts:              numExpiredCerts,
 			numExpiringCerts:             numExpiringCerts,
-			priorityModifier:             priorityModifierMinimum,
+			priorityModifier:             priorityModifierMedium,
 		}
 
 	case hasExpiringRootCerts &&


### PR DESCRIPTION
Adjust priority for expiring leaf or intermediate certificates from minimum to medium to better reflect importance of this result contrasted against other validation checks.