### PR TITLE
Clarify CertChainValidationResult.Priority

### DIFF
--- a/internal/certs/validation-expiration.go
+++ b/internal/certs/validation-expiration.go
@@ -672,6 +672,10 @@ func (evr ExpirationValidationResult) ServiceState() nagios.ServiceState {
 func (evr ExpirationValidationResult) Priority() int {
 	switch {
 	case evr.ignored:
+		// Though the result is ignored, we indicate the baseline value for
+		// this check result to allow this result to sort properly against
+		// other check results which may also be ignored. This why we don't
+		// use a value of 0 (or equivalent) here.
 		return baselinePriorityExpirationValidationResult
 	default:
 		return baselinePriorityExpirationValidationResult + evr.priorityModifier

--- a/internal/certs/validation-hostname.go
+++ b/internal/certs/validation-hostname.go
@@ -327,6 +327,10 @@ func (hnvr HostnameValidationResult) ServiceState() nagios.ServiceState {
 func (hnvr HostnameValidationResult) Priority() int {
 	switch {
 	case hnvr.ignored:
+		// Though the result is ignored, we indicate the baseline value for
+		// this check result to allow this result to sort properly against
+		// other check results which may also be ignored. This why we don't
+		// use a value of 0 (or equivalent) here.
 		return baselinePriorityHostnameValidationResult
 	default:
 		return baselinePriorityHostnameValidationResult + hnvr.priorityModifier

--- a/internal/certs/validation-results.go
+++ b/internal/certs/validation-results.go
@@ -155,7 +155,9 @@ type CertChainValidationResult interface {
 	// check performed.
 	//
 	// If the validation check result is flagged as ignored the priority
-	// modifier is also ignored.
+	// modifier is also ignored. In that case, the baseline value for the
+	// specific implementation is used to allow it to sort properly against
+	// other check result implementations which may also be ignored.
 	Priority() int
 
 	// CertChain returns the associated certificate chain which was evaluated.

--- a/internal/certs/validation-sans.go
+++ b/internal/certs/validation-sans.go
@@ -292,6 +292,10 @@ func (slvr SANsListValidationResult) ServiceState() nagios.ServiceState {
 func (slvr SANsListValidationResult) Priority() int {
 	switch {
 	case slvr.ignored:
+		// Though the result is ignored, we indicate the baseline value for
+		// this check result to allow this result to sort properly against
+		// other check results which may also be ignored. This why we don't
+		// use a value of 0 (or equivalent) here.
 		return baselinePrioritySANsListValidationResult
 	default:
 		return baselinePrioritySANsListValidationResult + slvr.priorityModifier


### PR DESCRIPTION
Update doc comments regarding behavior of each implementation for `CertChainValidationResult.Priority` and the interface itself to clarify intent behind the logic.