### PR TITLE
Clarify CertChainValidationResults.IsSucceeded

### DIFF
--- a/internal/certs/validation-expiration.go
+++ b/internal/certs/validation-expiration.go
@@ -638,7 +638,7 @@ func (evr ExpirationValidationResult) IsIgnored() bool {
 // IsSucceeded indicates whether this validation check result is not flagged
 // as ignored and no problems with the certificate chain were identified.
 func (evr ExpirationValidationResult) IsSucceeded() bool {
-	return evr.IsOKState() && !evr.IsIgnored()
+	return !evr.IsIgnored() && evr.Err() == nil
 }
 
 // IsFailed indicates whether this validation check result is not flagged as

--- a/internal/certs/validation-hostname.go
+++ b/internal/certs/validation-hostname.go
@@ -293,7 +293,7 @@ func (hnvr HostnameValidationResult) IsIgnored() bool {
 // IsSucceeded indicates whether this validation check result is not flagged
 // as ignored and no problems with the certificate chain were identified.
 func (hnvr HostnameValidationResult) IsSucceeded() bool {
-	return hnvr.IsOKState() && !hnvr.IsIgnored()
+	return !hnvr.IsIgnored() && hnvr.Err() == nil
 }
 
 // IsFailed indicates whether this validation check result is not flagged as

--- a/internal/certs/validation-sans.go
+++ b/internal/certs/validation-sans.go
@@ -258,7 +258,7 @@ func (slvr SANsListValidationResult) IsIgnored() bool {
 // IsSucceeded indicates whether this validation check result is not flagged
 // as ignored and no problems with the certificate chain were identified.
 func (slvr SANsListValidationResult) IsSucceeded() bool {
-	return slvr.IsOKState() && !slvr.IsIgnored()
+	return !slvr.IsIgnored() && slvr.Err() == nil
 }
 
 // IsFailed indicates whether this validation check result is not flagged as


### PR DESCRIPTION
Using the `IsOKState` method unintentionally made the logic harder to follow. While it technically worked, this commit emphasizes the requirement that no errors were encountered.