### PR TITLE
Initial implementation of chain order validation

### DIFF
--- a/cmd/check_cert/main_test.go
+++ b/cmd/check_cert/main_test.go
@@ -326,6 +326,37 @@ func TestApplyValidationResults(t *testing.T) {
 			validateFunc: config.Config.ApplyCertSANsListValidationResults,
 			applyResults: true,
 		},
+
+		{
+			name:                   "DefaultChainOrderResults",
+			server:                 "www.example.com",
+			validateFlagsAndValues: []string{},
+			validateFunc:           config.Config.ApplyCertChainOrderValidationResults,
+
+			// This validation is not part of the original set and has to be
+			// opted into.
+			applyResults: false,
+		},
+		{
+			name:   "IgnoreValidateChainOrderResults",
+			server: "www.example.com",
+			validateFlagsAndValues: []string{
+				"--" + config.IgnoreValidationResultFlag,
+				config.ValidationKeywordChainOrder,
+			},
+			validateFunc: config.Config.ApplyCertChainOrderValidationResults,
+			applyResults: false,
+		},
+		{
+			name:   "ApplyValidateChainOrderResults",
+			server: "www.example.com",
+			validateFlagsAndValues: []string{
+				"--" + config.ApplyValidationResultFlag,
+				config.ValidationKeywordChainOrder,
+			},
+			validateFunc: config.Config.ApplyCertChainOrderValidationResults,
+			applyResults: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/check_cert/perfdata.go
+++ b/cmd/check_cert/perfdata.go
@@ -67,6 +67,9 @@ func getPerfData(certChain []*x509.Certificate, ageCritical int, ageWarning int)
 	certsPresentRoot := strconv.Itoa(certs.NumRootCerts(certChain))
 	certsPresentUnknown := strconv.Itoa(certs.NumUnknownCerts(certChain))
 
+	certChainMisOrdered := strconv.Itoa(certs.NumMisorderedCerts(certChain))
+	certChainOrdered := strconv.Itoa(certs.NumOrderedCerts(certChain))
+
 	pd := []nagios.PerformanceData{
 		{
 			Label:             "expires_leaf",
@@ -97,6 +100,14 @@ func getPerfData(certChain []*x509.Certificate, ageCritical int, ageWarning int)
 		{
 			Label: "certs_present_unknown",
 			Value: certsPresentUnknown,
+		},
+		{
+			Label: "certs_ordered",
+			Value: certChainOrdered,
+		},
+		{
+			Label: "certs_misordered",
+			Value: certChainMisOrdered,
 		},
 		{
 			Label:             "life_remaining_leaf",

--- a/internal/certs/advice/root-cert-found.txt
+++ b/internal/certs/advice/root-cert-found.txt
@@ -1,0 +1,1 @@
+NOTE: A root cert was provided; including a root cert is *usually* not a problem, but be aware that some platforms object to this.

--- a/internal/certs/advice/sectigo-email-download-links.txt
+++ b/internal/certs/advice/sectigo-email-download-links.txt
@@ -1,0 +1,17 @@
+It looks like you are using a certificate provided by Sectigo (InCommon).
+
+If this is correct, these are the download options available to you in the
+"Enrollment Successful - Your SSL certificate for host1.example.com is ready"
+email notification you received:
+
+1. "as Certificate only, PEM encoded"
+2. "as Certificate (w/ issuer after), PEM encoded"
+3. "as Certificate (w/ chain), PEM encoded"
+4. "Issuing CA certificates only > as Root/Intermediate(s) only, PEM encoded"
+5. "Issuing CA certificates only > as Intermediate(s)/Root only, PEM encoded"
+
+While these options can be confusing, they can be summarized as:
+
+❌ FAIL: Option 4 when paired with Option 1 forms a misordered certificate chain.
+➖ GOOD: Option 4 appended to Option 1 provides a usable chain.
+✅ BEST: Option 2 is what sysadmins should use for best results.

--- a/internal/certs/validation-chain-order.go
+++ b/internal/certs/validation-chain-order.go
@@ -1,0 +1,756 @@
+// Copyright 2024 Adam Chalkley
+//
+// https://github.com/atc0005/check-cert
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package certs
+
+import (
+	"crypto/x509"
+	_ "embed"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/atc0005/go-nagios"
+)
+
+// Add an "implements assertion" to fail the build if the interface
+// implementation isn't correct.
+var _ CertChainValidationResult = (*ChainOrderValidationResult)(nil)
+
+// Advice for sysadmins resolving chain order issues saved in external files
+// for easier maintenance.
+var (
+	//go:embed advice/sectigo-email-download-links.txt
+	sectigoEmailAdvice string
+
+	//go:embed advice/root-cert-found.txt
+	rootCertFoundAdvice string
+)
+
+// ChainOrderValidationResult is the validation result from performing
+// expiration validation against each certificate in a chain.
+type ChainOrderValidationResult struct {
+	// certChain is the collection of certificates that we evaluated to
+	// produce this validation check result.
+	certChain []*x509.Certificate
+
+	// err is the "final" error describing the validation attempt.
+	err error
+
+	// ignored indicates whether validation check results are ignored for the
+	// certificate chain.
+	ignored bool
+
+	// validationOptions tracks what validation options were chosen by the
+	// sysadmin.
+	validationOptions CertChainValidationOptions
+
+	// verboseOutput indicates whether user has requested verbose validation
+	// results output.
+	verboseOutput bool
+
+	// omitSANsEntries indicates that SANs entries should be omitted in
+	// certificate report details.
+	omitSANsEntries bool
+
+	// numOrderedCerts is the number of certificates in the evaluated
+	// certificate chain which were found to be in the correct order.
+	numOrderedCerts int
+
+	// numMisorderedCerts is the number of certificates in the evaluated
+	// certificate chain which were found to be in an incorrect order.
+	numMisorderedCerts int
+
+	// priorityModifier is applied when calculating the priority for a
+	// validation check result. If a validation check result has an associated
+	// error but is flagged as ignored then the base priority value is used
+	// and this modifier is ignored.
+	//
+	// If the validation check is not flagged as ignored than this modifier is
+	// used to calculate the final priority level.
+	priorityModifier int
+}
+
+// ValidateChainOrder evaluates a given certificate chain for certificates out
+// of the expected order (leaf first followed by one or more intermediates).
+// If specified, a flag is set to generate verbose validation output.
+//
+// If requested, SANs entries on a leaf certificate are omitted.
+//
+// NOTE: This validation type objects to incorrect certificate entries (e.g.,
+// duplicate leaf certs) as it causes the chain to not be in the correct
+// order.
+func ValidateChainOrder(
+	certChain []*x509.Certificate,
+	verboseOutput bool,
+	omitSANsEntries bool,
+	validationOptions CertChainValidationOptions,
+) ChainOrderValidationResult {
+
+	// Perform basic validation of given values.
+	//
+	// What other "basics" do we check for before we perform chain order
+	// evaluation?
+	//
+	// Should we object to missing leaf certificates; should we handle
+	// intermediates bundle monitoring any differently?
+
+	if len(certChain) == 0 {
+		return ChainOrderValidationResult{
+			certChain:         certChain,
+			validationOptions: validationOptions,
+			err: fmt.Errorf(
+				"required certificate chain is empty: %w",
+				ErrIncompleteCertificateChain,
+			),
+			ignored:          validationOptions.IgnoreValidationResultChainOrder,
+			priorityModifier: priorityModifierMaximum,
+		}
+	}
+
+	hasMisorderedCerts := HasMisorderedCerts(certChain)
+	numOrderedCerts := NumOrderedCerts(certChain)
+	numMisorderedCerts := NumMisorderedCerts(certChain)
+
+	// Perform chain order evaluation.
+	switch {
+	case len(certChain) == 1:
+		// While this focus is primarily on a cert "chain" containing only a
+		// valid leaf certificate (signed by a trusted intermediate), we also
+		// (currently) assume that self-signed certificates are an ordering
+		// issue that requires resolution.
+
+		certType := ChainPosition(certChain[0], certChain)
+
+		return ChainOrderValidationResult{
+			certChain:         certChain,
+			validationOptions: validationOptions,
+			err: fmt.Errorf(
+				"certificate chain contains only %s cert: %w",
+				certType,
+				ErrIncompleteCertificateChain,
+			),
+			ignored:          validationOptions.IgnoreValidationResultChainOrder,
+			priorityModifier: priorityModifierMedium,
+		}
+
+	case hasMisorderedCerts:
+		return ChainOrderValidationResult{
+			certChain: certChain,
+			err: fmt.Errorf(
+				"chain order validation failed: %w",
+				ErrMisorderedCertificateChain,
+			),
+			ignored:            validationOptions.IgnoreValidationResultChainOrder,
+			validationOptions:  validationOptions,
+			verboseOutput:      verboseOutput,
+			omitSANsEntries:    omitSANsEntries,
+			numOrderedCerts:    numOrderedCerts,
+			numMisorderedCerts: numMisorderedCerts,
+			priorityModifier:   priorityModifierMedium,
+		}
+
+	default:
+		// No chain order issues found.
+		return ChainOrderValidationResult{
+			certChain:          certChain,
+			err:                nil,
+			ignored:            validationOptions.IgnoreValidationResultChainOrder,
+			validationOptions:  validationOptions,
+			verboseOutput:      verboseOutput,
+			omitSANsEntries:    omitSANsEntries,
+			numOrderedCerts:    numOrderedCerts,
+			numMisorderedCerts: numMisorderedCerts,
+			priorityModifier:   priorityModifierBaseline,
+		}
+	}
+}
+
+// CheckName emits the human-readable name of this validation check result.
+func (covr ChainOrderValidationResult) CheckName() string {
+	return checkNameChainOrderValidationResult
+}
+
+// CertChain returns the evaluated certificate chain.
+func (covr ChainOrderValidationResult) CertChain() []*x509.Certificate {
+	return covr.certChain
+}
+
+// TotalCerts returns the number of certificates in the evaluated certificate
+// chain.
+func (covr ChainOrderValidationResult) TotalCerts() int {
+	return len(covr.certChain)
+}
+
+// IsWarningState indicates whether this validation check result is in a
+// WARNING state. This returns false if the validation check resulted in an OK
+// or CRITICAL state, or is flagged as ignored. True is returned otherwise.
+func (covr ChainOrderValidationResult) IsWarningState() bool {
+	if covr.IsIgnored() {
+		return false
+	}
+
+	// A "misordered" certificate chain is considered a WARNING state and not
+	// CRITICAL because the majority of modern clients (e.g., browsers) will
+	// automatically rearrange a given certificate chain into an valid order,
+	// provided that the leaf and intermediate certificates are present.
+	switch {
+	case errors.Is(covr.err, ErrMisorderedCertificateChain):
+		// We explicitly handle this specific error type vs letting a more
+		// general match handle "anything not incomplete error chain error".
+		// This is as much to document the intent as to provide a hook for
+		// future use.
+		return true
+
+	// An incomplete certificate chain is considered a CRITICAL state; if any
+	// other error has occurred we'll consider that a WARNING state.
+	case covr.err != nil &&
+		!errors.Is(covr.err, ErrIncompleteCertificateChain):
+
+		return true
+
+	default:
+		return false
+	}
+}
+
+// IsCriticalState indicates whether this validation check result is in a
+// CRITICAL state. This returns false if the validation check resulted in an
+// OK or WARNING state, or is flagged as ignored. True is returned otherwise.
+func (covr ChainOrderValidationResult) IsCriticalState() bool {
+	if covr.IsIgnored() {
+		return false
+	}
+
+	// An incomplete certificate chain is considered a CRITICAL state because
+	// required certificates are not present; because some modern/current
+	// clients will not automatically fetch missing intermediates to resolve
+	// the chain users are more likely to be impacted by this problem than
+	// they would be if the chain were misordered.
+	switch {
+	case errors.Is(covr.err, ErrIncompleteCertificateChain):
+		return true
+
+	default:
+		return false
+	}
+}
+
+// IsUnknownState indicates whether this validation check result is in an
+// UNKNOWN state.
+func (covr ChainOrderValidationResult) IsUnknownState() bool {
+	// This state is not used for this certificate validation check.
+	return false
+}
+
+// IsOKState indicates whether this validation check result is in an OK or
+// passing state. For the purposes of validation check evaluation, ignored
+// validation checks are considered to be a subset of OK status.
+func (covr ChainOrderValidationResult) IsOKState() bool {
+	return covr.err == nil || covr.IsIgnored()
+}
+
+// IsIgnored indicates whether this validation check result was flagged as
+// ignored for the purposes of determining final validation state.
+func (covr ChainOrderValidationResult) IsIgnored() bool {
+	return covr.ignored
+}
+
+// IsSucceeded indicates whether this validation check result is not flagged
+// as ignored and no problems with the certificate chain were identified.
+func (covr ChainOrderValidationResult) IsSucceeded() bool {
+	return covr.IsOKState() && !covr.IsIgnored()
+}
+
+// IsFailed indicates whether this validation check result is not flagged as
+// ignored and problems were identified.
+func (covr ChainOrderValidationResult) IsFailed() bool {
+	return covr.err != nil && !covr.IsIgnored()
+}
+
+// Err returns the underlying error (if any) regardless of whether this
+// validation check result is flagged as ignored.
+func (covr ChainOrderValidationResult) Err() error {
+	return covr.err
+}
+
+// ServiceState returns the appropriate Service Check Status label and exit
+// code for this validation check result.
+func (covr ChainOrderValidationResult) ServiceState() nagios.ServiceState {
+	return ServiceState(covr)
+}
+
+// Priority indicates the level of importance for this validation check
+// result.
+//
+// This value is calculated by applying a priority modifier for specific
+// failure conditions (recorded when the validation check result is
+// initially obtained) to a baseline value specific to the validation
+// check performed.
+//
+// If the validation check result is flagged as ignored the priority
+// modifier is also ignored.
+func (covr ChainOrderValidationResult) Priority() int {
+	switch {
+	case covr.ignored:
+		// Though the result is ignored, we indicate the baseline value for
+		// this check result to allow this result to sort properly against
+		// other check results which may also be ignored. This why we don't
+		// use a value of 0 (or equivalent) here.
+		return baselinePriorityChainOrderValidationResult
+	default:
+		return baselinePriorityChainOrderValidationResult + covr.priorityModifier
+	}
+}
+
+// Overview provides a high-level summary of this validation check result.
+func (covr ChainOrderValidationResult) Overview() string {
+	return fmt.Sprintf(
+		"[ORDERED: %d, MISORDERED: %d, TOTAL: %d]",
+		covr.NumOrderedCerts(),
+		covr.NumMisorderedCerts(),
+		covr.TotalCerts(),
+	)
+}
+
+// Status is intended as a brief status of the validation check result. This
+// can be used as initial lead-in text.
+func (covr ChainOrderValidationResult) Status() string {
+	var summary string
+
+	switch {
+	case errors.Is(covr.err, ErrMisorderedCertificateChain):
+		summary = fmt.Sprintf(
+			"%s validation %s: %d certs misordered",
+			covr.CheckName(),
+			covr.ValidationStatus(),
+			covr.NumMisorderedCerts(),
+		)
+
+	case errors.Is(covr.err, ErrIncompleteCertificateChain):
+		summary = fmt.Sprintf(
+			"%s validation %s: %s",
+			covr.CheckName(),
+			covr.ValidationStatus(),
+
+			// The error message is already verbose enough that we don't
+			// really need to add extra qualifiers in the summary text.
+			covr.err.Error(),
+		)
+
+	// Catchall error handling
+	case covr.err != nil:
+		summary = fmt.Sprintf(
+			"%s validation %s: unexpected error encountered while validating %d certs: %s",
+			covr.CheckName(),
+			covr.ValidationStatus(),
+			covr.TotalCerts(),
+			covr.err.Error(),
+		)
+
+	// Success / OK scenario
+	default:
+		summary = fmt.Sprintf(
+			"%s validation %s: %d certs present, %d certs misordered",
+			covr.CheckName(),
+			covr.ValidationStatus(),
+			covr.TotalCerts(),
+			covr.NumMisorderedCerts(),
+		)
+	}
+
+	return summary
+}
+
+// StatusDetail provides additional details intended to extend the shorter
+// status text with information suitable as explanation for the overall state
+// of the validation check result. This text may span multiple lines.
+func (covr ChainOrderValidationResult) StatusDetail() string {
+	// NOTE: This is called from the Report() method and is used to compose
+	// that larger output block.
+
+	var detail strings.Builder
+
+	switch {
+	case errors.Is(covr.err, ErrMisorderedCertificateChain):
+		detail.WriteString(
+			fmt.Sprintf(
+				"A misordered certificate chain was found!%s",
+				nagios.CheckOutputEOL,
+			),
+		)
+
+		detail.WriteString(reorderChainAdvice(covr.certChain))
+
+	case errors.Is(covr.err, ErrIncompleteCertificateChain):
+		detail.WriteString(
+			fmt.Sprintf(
+				"An incomplete certificate chain was found (%d certs total).%s%s",
+				covr.TotalCerts(),
+				nagios.CheckOutputEOL,
+				nagios.CheckOutputEOL,
+			),
+		)
+
+		detail.WriteString(incompleteChainAdvice(covr.certChain))
+
+	// Catchall error handling
+	case covr.err != nil:
+		detail.WriteString(
+			fmt.Sprintf(
+				"An unexpected error occurred while performing chain order validation!%s",
+				nagios.CheckOutputEOL,
+			),
+		)
+
+		detail.WriteString(
+			fmt.Sprintf(
+				"Please report the following error and provide a copy of your certificate chain for evaluation (e.g., see cpcert tool in this project).%s%s",
+				nagios.CheckOutputEOL,
+				nagios.CheckOutputEOL,
+			),
+		)
+
+		detail.WriteString(
+			fmt.Sprintf(
+				"Error: %q%s",
+				covr.err.Error(),
+				nagios.CheckOutputEOL,
+			),
+		)
+
+	// Success / OK scenario
+	default:
+		// TODO: Anything extra to add for successful chain order validation?
+		// The Status() output is likely sufficient to cover this.
+	}
+
+	return detail.String()
+}
+
+// String provides the validation check result in human-readable format.
+// Because the certificates chain report is so detailed we skip emitting those
+// details.
+func (covr ChainOrderValidationResult) String() string {
+	return fmt.Sprintf(
+		"%s %s",
+		covr.Status(),
+		covr.Overview(),
+	)
+}
+
+// Report provides the validation check result in verbose human-readable
+// format. Trailing whitespace is intentionally omitted per
+// CertChainValidationResult recommendation.
+func (covr ChainOrderValidationResult) Report() string {
+	switch {
+	// Show advice regardless of whether check results were ignored (for the
+	// purposes of determining final plugin check state).
+	case covr.err != nil:
+		return fmt.Sprintf(
+			"%s %s%s%s",
+			covr.Status(),
+			nagios.CheckOutputEOL,
+			nagios.CheckOutputEOL,
+			covr.StatusDetail(),
+		)
+
+	default:
+		statusSummary := fmt.Sprintf(
+			"%d ordered certificates, %d misordered certificates",
+			covr.numOrderedCerts,
+			covr.numMisorderedCerts,
+		)
+
+		// Provide overview only.
+		return fmt.Sprintf(
+			"%s validation %s: %s",
+			covr.CheckName(),
+			covr.ValidationStatus(),
+			statusSummary,
+		)
+	}
+}
+
+// NumOrderedCerts indicates the number of certificates in the chain that are
+// not out of order.
+func (covr ChainOrderValidationResult) NumOrderedCerts() int {
+	return NumOrderedCerts(covr.CertChain())
+}
+
+// NumMisorderedCerts indicates the number of certificates in the chain that are
+// not out of order.
+func (covr ChainOrderValidationResult) NumMisorderedCerts() int {
+	return NumMisorderedCerts(covr.CertChain())
+}
+
+// ValidationStatus provides a one word status value for expiration validation
+// check results. If the original certificate chain was filtered then the
+// validation status value is based on the filtered chain, otherwise the
+// original certificate chain is used.
+func (covr ChainOrderValidationResult) ValidationStatus() string {
+	switch {
+	case covr.IsFailed():
+		return ValidationStatusFailed
+	case covr.IsIgnored():
+		return ValidationStatusIgnored
+	default:
+		return ValidationStatusSuccessful
+	}
+}
+
+// summarizeChainOrder returns a summarized list of the certificates in a
+// given certificate chain.
+func summarizeChainOrder(certChain []*x509.Certificate) string {
+	var chainOrderList strings.Builder
+
+	hostVal := func(cert *x509.Certificate) string {
+		switch {
+		case cert.Subject.CommonName != "":
+			return cert.Subject.CommonName
+
+		case len(cert.DNSNames) > 0:
+			return cert.DNSNames[0]
+
+		default:
+			return "unknown cert"
+		}
+	}
+
+	template := "(%d) %s [%s]%s"
+	// template := "[%d] %s (%s)%s"
+
+	for idx, cert := range certChain {
+		chainPos := ChainPosition(cert, certChain)
+		chainOrderList.WriteString(
+			fmt.Sprintf(
+				template,
+				idx,
+				hostVal(cert),
+				chainPos,
+				nagios.CheckOutputEOL,
+			),
+		)
+	}
+
+	return chainOrderList.String()
+}
+
+// summarizeFixedChainOrder returns a summarized list of the certificates in a
+// given certificate chain in a fixed chain order.
+func summarizeFixedChainOrder(certChain []*x509.Certificate) string {
+	orderedCertChain := orderCertChain(certChain)
+
+	return summarizeChainOrder(orderedCertChain)
+}
+
+// reorderChainAdvice provides advice for the sysadmin when a cert chain is
+// found to be misordered.
+func reorderChainAdvice(certChain []*x509.Certificate) string {
+	if len(certChain) == 0 {
+		return ""
+	}
+
+	var advice strings.Builder
+
+	advice.WriteString(
+		fmt.Sprintf(
+			"This issue is often caused by using the incorrect intermediates bundle (with reversed entries).%s",
+			nagios.CheckOutputEOL,
+		),
+	)
+
+	advice.WriteString(
+		fmt.Sprintf(
+			"It is recommended that you reorder the certificate chain to resolve this issue.%s%s",
+			nagios.CheckOutputEOL,
+			nagios.CheckOutputEOL,
+		),
+	)
+
+	advice.WriteString(
+		fmt.Sprintf(
+			"Current chain order:%s%s%s%s",
+			nagios.CheckOutputEOL,
+			nagios.CheckOutputEOL,
+			summarizeChainOrder(certChain),
+			nagios.CheckOutputEOL,
+		),
+	)
+
+	advice.WriteString(
+		fmt.Sprintf(
+			"Recommended chain order:%s%s%s%s",
+			nagios.CheckOutputEOL,
+			nagios.CheckOutputEOL,
+			summarizeFixedChainOrder(certChain),
+			nagios.CheckOutputEOL,
+		),
+	)
+
+	advice.WriteString(certDownloadLinksAdvice(certChain))
+
+	// FIXME: Move this somewhere it can be used regardless of any actual
+	// chain ordering issue; ideally this would be noted if all chain elements
+	// are in the correct order but a root certificate is provided.
+	//
+	// This may fit best as a default check/note within a new validation check
+	// dedicated to looking for inclusion of the root cert, or later as an
+	// error condition once it becomes more unusual for cert chains to contain
+	// a root.
+	if HasRootCert(certChain) {
+		advice.WriteString(
+			fmt.Sprintf(
+				"%s%s%s",
+				nagios.CheckOutputEOL,
+				strings.TrimSpace(rootCertFoundAdvice),
+				nagios.CheckOutputEOL,
+			),
+		)
+	}
+
+	return advice.String()
+}
+
+// incompleteChainAdvice provides advice for the sysadmin when a cert chain is
+// found to be incomplete.
+func incompleteChainAdvice(certChain []*x509.Certificate) string {
+	if len(certChain) == 0 {
+		return ""
+	}
+
+	var advice strings.Builder
+
+	advice.WriteString(
+		fmt.Sprintf(
+			"This issue often occurs with Windows Servers when (newer) intermediates are missing from the certificate stores.%s",
+			nagios.CheckOutputEOL,
+		),
+	)
+
+	hostValRef := func(chain []*x509.Certificate) string {
+		switch {
+		case chain[0].Subject.CommonName != "":
+			return fmt.Sprintf(
+				" for %s ",
+				chain[0].Subject.CommonName,
+			)
+
+		case len(chain[0].DNSNames) > 0:
+			return fmt.Sprintf(
+				" for %s ",
+				chain[0].DNSNames[0],
+			)
+
+		default:
+			return ""
+		}
+	}
+
+	firstCertType := ChainPosition(certChain[0], certChain)
+
+	isMissingIntermediates := !HasIntermediateCert(certChain)
+
+	switch {
+	case firstCertType == certChainPositionLeafSelfSigned:
+		advice.WriteString(
+			fmt.Sprintf(
+				"It is recommended that you replace the %s certificate with a valid certificate chain.%s",
+				certChainPositionLeafSelfSigned,
+				nagios.CheckOutputEOL,
+			),
+		)
+
+	case isMissingIntermediates:
+		advice.WriteString(
+			fmt.Sprintf(
+				"It is recommended that you configure the service%sto include the missing intermediates.%s",
+				hostValRef(certChain),
+				nagios.CheckOutputEOL,
+			),
+		)
+
+		advice.WriteString(certDownloadLinksAdvice(certChain))
+
+	default:
+
+		// Any advice for this scenario?
+	}
+
+	return advice.String()
+}
+
+// certDownloadLinksAdvice attempts to provide sysadmins advice for what
+// download links to use when repairing reported certificate chain issues.
+func certDownloadLinksAdvice(certChain []*x509.Certificate) string {
+	if len(certChain) == 0 {
+		return ""
+	}
+
+	var advice strings.Builder
+
+	if !HasLeafCert(certChain) {
+		advice.WriteString(
+			"NOTE: No leaf certs detected in given certificate chain;" +
+				" is this an intermediates bundle that is being monitored?",
+		)
+	}
+
+	type adviceMapEntry struct {
+		CA           string
+		CASubstrings []string
+		Description  string
+		Advice       string
+	}
+
+	adviceMappings := []adviceMapEntry{
+		{
+			CASubstrings: []string{
+				"InCommon",
+				"USERTrust",
+				"COMODO",
+				"Sectigo",
+			},
+			Description: "Known CA name prefixes used by Sectigo",
+			Advice:      strings.TrimSpace(sectigoEmailAdvice),
+		},
+	}
+
+outerLoop:
+	for _, cert := range certChain {
+		for _, adviceEntry := range adviceMappings {
+			for _, pattern := range adviceEntry.CASubstrings {
+				lowerCasePattern := strings.ToLower(pattern)
+
+				issuerContainsCAPrefix := strings.Contains(
+					strings.ToLower(cert.Issuer.CommonName),
+					lowerCasePattern,
+				)
+
+				issuedContainsCAPrefix := strings.Contains(
+					strings.ToLower(cert.Subject.CommonName),
+					lowerCasePattern,
+				)
+
+				if issuerContainsCAPrefix || issuedContainsCAPrefix {
+					advice.WriteString(
+						fmt.Sprintf(
+							"%s%s%s",
+							nagios.CheckOutputEOL,
+							adviceEntry.Advice,
+							nagios.CheckOutputEOL,
+						),
+					)
+
+					break outerLoop
+				}
+			}
+		}
+	}
+
+	return advice.String()
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -347,6 +347,12 @@ func TestApplyIgnoreDecision(t *testing.T) {
 			applyResults: false,
 		},
 		{
+			name:         "DefaultValidateChainOrderResults",
+			cfg:          Config{},
+			validateFunc: Config.ApplyCertChainOrderValidationResults,
+			applyResults: defaultApplyCertChainOrderValidationResults,
+		},
+		{
 			name: "DefaultValidateSANsListResultsWithSANsEntries",
 			cfg: Config{
 				SANsEntries: []string{"tacos.example.com"},
@@ -368,6 +374,22 @@ func TestApplyIgnoreDecision(t *testing.T) {
 				applyValidationResults: []string{ValidationKeywordSANsList},
 			},
 			validateFunc: Config.ApplyCertSANsListValidationResults,
+			applyResults: true,
+		},
+		{
+			name: "IgnoreValidateChainOrderResults",
+			cfg: Config{
+				ignoreValidationResults: []string{ValidationKeywordChainOrder},
+			},
+			validateFunc: Config.ApplyCertChainOrderValidationResults,
+			applyResults: false,
+		},
+		{
+			name: "ApplyValidateChainOrderResults",
+			cfg: Config{
+				applyValidationResults: []string{ValidationKeywordChainOrder},
+			},
+			validateFunc: Config.ApplyCertChainOrderValidationResults,
 			applyResults: true,
 		},
 	}

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -159,6 +159,7 @@ const (
 	ValidationKeywordExpiration string = "expiration"
 	ValidationKeywordHostname   string = "hostname"
 	ValidationKeywordSANsList   string = "sans"
+	ValidationKeywordChainOrder string = "order"
 )
 
 // Certificate type keywords used when filtering specific certificate types
@@ -239,6 +240,18 @@ const (
 	//
 	// This is set based on existing behavior in prior stable releases.
 	defaultApplyCertSANsListValidationResults bool = true
+
+	// Whether Chain order validation check results should be applied when
+	// determining overall validation state of a certificate chain by default.
+	//
+	// This is set based on existing behavior in prior stable releases; since
+	// this validation type did not exist in early stable releases we
+	// introduce this validation type with validation ignored by default.
+	//
+	// NOTE: A future version may enable this by default after an announcement
+	// has been made and sufficient time has passed to allow sysadmins to
+	// explicitly opt out.
+	defaultApplyCertChainOrderValidationResults bool = false
 )
 
 // Constants specific to the copier app.

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -178,6 +178,29 @@ func (c Config) ApplyCertSANsListValidationResults() bool {
 
 }
 
+// ApplyCertChainOrderValidationResults indicates whether certificate chain
+// order check results should be applied when performing final plugin state
+// evaluation. Precedence is given for explicit request to ignore this
+// validation result.
+func (c Config) ApplyCertChainOrderValidationResults() bool {
+	ignoreRequested := textutils.InList(
+		ValidationKeywordChainOrder, c.ignoreValidationResults, true,
+	)
+
+	applyRequested := textutils.InList(
+		ValidationKeywordChainOrder, c.applyValidationResults, true,
+	)
+
+	switch {
+	case ignoreRequested:
+		return false
+	case applyRequested:
+		return true
+	default:
+		return defaultApplyCertChainOrderValidationResults
+	}
+}
+
 // supportedValidationCheckResultKeywords returns a list of valid validation
 // check keywords used by plugin type applications in this project.
 func supportedValidationCheckResultKeywords() []string {
@@ -185,6 +208,7 @@ func supportedValidationCheckResultKeywords() []string {
 		ValidationKeywordHostname,
 		ValidationKeywordExpiration,
 		ValidationKeywordSANsList,
+		ValidationKeywordChainOrder,
 	}
 }
 

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -137,6 +137,7 @@ func (c *Config) setupLogging(appType AppType) error {
 			Bool("apply_hostname_validation_results", c.ApplyCertHostnameValidationResults()).
 			Bool("apply_expiration_validation_results", c.ApplyCertExpirationValidationResults()).
 			Bool("apply_sans_list_validation_results", c.ApplyCertSANsListValidationResults()).
+			Bool("apply_chain_order_validation_results", c.ApplyCertChainOrderValidationResults()).
 			// TODO: Extend with further validation check names.
 			Logger()
 


### PR DESCRIPTION
## Overview

This set of changes applies to both the `check_cert` plugin and the `lscert` CLI tool. While the primary focus is adding a prototype implementation of "chain order" validation logic, other ergonomic and display changes have been applied to the `lscert` tool. Some of those changes are likely to be refined further in near future releases as additional validation checks are applied.

## Changes

- update `check_cert` plugin
  - add new `Chain Order` validation type
    - assert that leaf certificate is first in chain, followed by the intermediate which signed it, a potential second intermediate which signed the former and so on
    - current implementation objects to a single leaf cert in a chain, though this behavior may be moved to a separate validation check specific to intermediates
    - current implementation notes the presence of a root certificate and cautions that some platforms will object to this, though this behavior may be moved to a separate validation check in the future
    - offers advice for replacing a certificate chain when specific CA vendors are matched
      - currently only Sectigo/InCommon is supported, though the plan is to support multiple CAs once further feedback is gathered
  - add new performance data metrics
    - `certs_ordered`
    - `certs_misordered`
  - extend tests to cover new validation type
- update `lscert`
  - incorporate new validation check
  - rework summary display to use emoji status indicators (pass/neutral/warn/crit)
  - rename headers to emphasize "cert chain" over just "certs"
  - incorporate the same "advice" output that the `check_cert` plugin now emits for `Chain Order` validation problems

## Credit

The following LLM sources were used for inspiration or starting code samples for some of the included changes:

- ChatGPT, OpenAI
- Google Gemini
- Claude (Anthropic AI assistant)

In particular, I used all of these sources for assistance with logic for certificate chain ordering, signature validation and misc other tasks. While none provided solutions I could use as-is, all were helpful in pointing me in the right direction when I needed it.

## References

- GH-1004
- GH-364
- GH-365
- GH-219