### PR TITLE
Update doc comments for default connection timeout

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -193,7 +193,7 @@ const (
 	defaultCertExpireAgeCritical int = 15
 
 	// Default timeout (in seconds) used when retrieving a certificate from a
-	// specified TCP port previously discovered to be open.
+	// specified TCP port.
 	defaultConnectTimeout int = 10
 
 	// Default choice of whether Go 1.17+ behavior of failing hostname


### PR DESCRIPTION
Update doc comments to remove indicator that this timeout only comes into play after confirming TCP port is open (while that may apply to certsum it does not currently apply to other tools in this project).

refs GH-380