### PR TITLE
Drop OmitSANsEntries from Chain Order validation

### DIFF
--- a/cmd/check_cert/validate.go
+++ b/cmd/check_cert/validate.go
@@ -150,7 +150,6 @@ func runValidationChecks(cfg *config.Config, certChain []*x509.Certificate, log 
 	chainOrderValidationResult := certs.ValidateChainOrder(
 		certChain,
 		cfg.VerboseOutput,
-		cfg.OmitSANsEntries,
 		chainOrderValidationOptions,
 	)
 	validationResults.Add(chainOrderValidationResult)

--- a/cmd/lscert/main.go
+++ b/cmd/lscert/main.go
@@ -494,7 +494,6 @@ func main() {
 	chainOrderValidationResult := certs.ValidateChainOrder(
 		certChain,
 		cfg.VerboseOutput,
-		cfg.OmitSANsEntries,
 		certs.CertChainValidationOptions{
 			// IgnoreValidationResultChainOrder: !cfg.ApplyCertChainOrderValidationResults(),
 			IgnoreValidationResultChainOrder: false,

--- a/internal/certs/validation-chain-order.go
+++ b/internal/certs/validation-chain-order.go
@@ -53,10 +53,6 @@ type ChainOrderValidationResult struct {
 	// results output.
 	verboseOutput bool
 
-	// omitSANsEntries indicates that SANs entries should be omitted in
-	// certificate report details.
-	omitSANsEntries bool
-
 	// numOrderedCerts is the number of certificates in the evaluated
 	// certificate chain which were found to be in the correct order.
 	numOrderedCerts int
@@ -87,7 +83,6 @@ type ChainOrderValidationResult struct {
 func ValidateChainOrder(
 	certChain []*x509.Certificate,
 	verboseOutput bool,
-	omitSANsEntries bool,
 	validationOptions CertChainValidationOptions,
 ) ChainOrderValidationResult {
 
@@ -148,7 +143,6 @@ func ValidateChainOrder(
 			ignored:            validationOptions.IgnoreValidationResultChainOrder,
 			validationOptions:  validationOptions,
 			verboseOutput:      verboseOutput,
-			omitSANsEntries:    omitSANsEntries,
 			numOrderedCerts:    numOrderedCerts,
 			numMisorderedCerts: numMisorderedCerts,
 			priorityModifier:   priorityModifierMedium,
@@ -162,7 +156,6 @@ func ValidateChainOrder(
 			ignored:            validationOptions.IgnoreValidationResultChainOrder,
 			validationOptions:  validationOptions,
 			verboseOutput:      verboseOutput,
-			omitSANsEntries:    omitSANsEntries,
 			numOrderedCerts:    numOrderedCerts,
 			numMisorderedCerts: numMisorderedCerts,
 			priorityModifier:   priorityModifierBaseline,


### PR DESCRIPTION
This value appears to have been mistakenly retained when copying/pasting/modifying an existing implementation of the `CertChainValidationResult` interface to create the `ChainOrderValidationResult` implementation.