### PR TITLE
Return ErrNoCertsFound error when chain is empty

### DIFF
--- a/internal/certs/validation-chain-order.go
+++ b/internal/certs/validation-chain-order.go
@@ -100,7 +100,7 @@ func ValidateChainOrder(
 			validationOptions: validationOptions,
 			err: fmt.Errorf(
 				"required certificate chain is empty: %w",
-				ErrIncompleteCertificateChain,
+				ErrNoCertsFound,
 			),
 			ignored:          validationOptions.IgnoreValidationResultChainOrder,
 			priorityModifier: priorityModifierMaximum,

--- a/internal/certs/validation-expiration.go
+++ b/internal/certs/validation-expiration.go
@@ -135,7 +135,7 @@ func ValidateExpiration(
 			validationOptions: validationOptions,
 			err: fmt.Errorf(
 				"required certificate chain is empty: %w",
-				ErrIncompleteCertificateChain,
+				ErrNoCertsFound,
 			),
 			ignored:          validationOptions.IgnoreValidationResultExpiration,
 			priorityModifier: priorityModifierMaximum,

--- a/internal/certs/validation-hostname.go
+++ b/internal/certs/validation-hostname.go
@@ -127,7 +127,7 @@ func ValidateHostname(
 			ignoreIfSANsEmptyFlagName: ignoreIfSANsEmptyFlagName,
 			err: fmt.Errorf(
 				"required certificate chain is empty: %w",
-				ErrIncompleteCertificateChain,
+				ErrNoCertsFound,
 			),
 			ignored:          validationOptions.IgnoreValidationResultHostname,
 			priorityModifier: priorityModifierMaximum,

--- a/internal/certs/validation-sans.go
+++ b/internal/certs/validation-sans.go
@@ -95,7 +95,7 @@ func ValidateSANsList(
 			validationOptions: validationOptions,
 			err: fmt.Errorf(
 				"required certificate chain is empty: %w",
-				ErrIncompleteCertificateChain,
+				ErrNoCertsFound,
 			),
 			ignored:          validationOptions.IgnoreValidationResultSANs,
 			priorityModifier: priorityModifierMaximum,


### PR DESCRIPTION
This alters a recent change in behavior to return
the `ErrIncompleteCertificateChain` error in place of the more generic `ErrMissingValue` error value previously used.

Now, we return the more appropriate `ErrNoCertsFound` error value from all current validation checks when an empty certificate chain is detected.

Some further work is needed to update WARNING and CRITICAL state detection to look for an `ErrNoCertsFound` error and treat it as an appropriate state.

- refs GH-1155
- refs GH-1167