### PR TITLE
Fix CRITICAL expiration state detection

### DIFF
--- a/internal/certs/validation-expiration.go
+++ b/internal/certs/validation-expiration.go
@@ -621,6 +621,9 @@ func (evr ExpirationValidationResult) IsCriticalState() bool {
 		//
 		return true
 
+	case HasExpiredCert(evr.FilteredCertificateChain()):
+		return true
+
 	case HasExpiringCert(evr.FilteredCertificateChain(), evr.ageCriticalThreshold):
 		return true
 


### PR DESCRIPTION
## Overview

Add back dropped `HasExpiredCert` check to the `ExpirationValidationResult.IsCriticalState` method. This was unintentionally removed as part of a recent refactoring effort.

## References

- GH-1196