### PR TITLE
Switch dev branch to Go 1.24rc1

### DIFF
--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.23.4
+FROM golang:1.24rc1


### PR DESCRIPTION
Switch to pre-release Go 1.24 series ahead of official stable release.