### PR TITLE
Fix SANs length check in expiration validation

### DIFF
--- a/internal/certs/validation-expiration.go
+++ b/internal/certs/validation-expiration.go
@@ -727,7 +727,7 @@ func (evr ExpirationValidationResult) Status() string {
 
 	// but if it is, use the first SubjectAlternateName field in its place
 	if nextCertToExpire.Subject.CommonName == "" {
-		if len(nextCertToExpire.DNSNames[0]) > 0 {
+		if len(nextCertToExpire.DNSNames) > 0 {
 			nextCertToExpireServerName = nextCertToExpire.DNSNames[0]
 		}
 	}


### PR DESCRIPTION
Replace unintentional check of the first SANs entry's length with the intended length check of the collection itself.

refs GH-1235