### PR TITLE
Fix `copyloopvar` linting errors

### DIFF
--- a/cmd/check_cert/main_test.go
+++ b/cmd/check_cert/main_test.go
@@ -153,10 +153,12 @@ func TestApplyIgnoreValidationFlagsForConfigValidationErrors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		// Make scopelint linter happy
 		// https://stackoverflow.com/questions/68559574/using-the-variable-on-range-scope-x-in-function-literal-scopelint
-		tt := tt
+		//
+		// NOTE: Not needed as of Go 1.22.
+		//
+		// tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			// Save old command-line arguments so that we can restore them later
@@ -391,10 +393,12 @@ func TestApplyValidationResults(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		// Make scopelint linter happy
 		// https://stackoverflow.com/questions/68559574/using-the-variable-on-range-scope-x-in-function-literal-scopelint
-		tt := tt
+		//
+		// NOTE: Not needed as of Go 1.22.
+		//
+		// tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -58,10 +58,12 @@ func TestExpirationAgeThresholds(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		// Make scopelint linter happy
 		// https://stackoverflow.com/questions/68559574/using-the-variable-on-range-scope-x-in-function-literal-scopelint
-		tt := tt
+		//
+		// NOTE: Not needed as of Go 1.22.
+		//
+		// tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			// Save old command-line arguments so that we can restore them later
@@ -262,10 +264,12 @@ func TestConfigValidationForCheckResultsFlags(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		// Make scopelint linter happy
 		// https://stackoverflow.com/questions/68559574/using-the-variable-on-range-scope-x-in-function-literal-scopelint
-		tt := tt
+		//
+		// NOTE: Not needed as of Go 1.22.
+		//
+		// tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 
@@ -417,10 +421,12 @@ func TestApplyIgnoreDecision(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		// Make scopelint linter happy
 		// https://stackoverflow.com/questions/68559574/using-the-variable-on-range-scope-x-in-function-literal-scopelint
-		tt := tt
+		//
+		// NOTE: Not needed as of Go 1.22.
+		//
+		// tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 


### PR DESCRIPTION
Comment out workarounds for `G601: Implicit memory aliasing`.