### PR TITLE
Switch dev branch to Go 1.24.0

### DIFF
--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.24rc3
+FROM golang:1.24.0


### PR DESCRIPTION
Switch pre-release Go 1.24 series canary file to initial stable release.