### PR TITLE
Enable insecure TLS ciphers and protocol versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,30 @@ module github.com/atc0005/check-cert
 
 go 1.23.0
 
+godebug (
+	// Go 1.23 changed the default TLS cipher suites used by clients and
+	// servers when not explicitly configured, removing 3DES cipher suites. We
+	// revert this behavior to support retrieving certificates from older
+	// systems.
+	//
+	// See also: https://pkg.go.dev/crypto/tls#Config.CipherSuites
+	tls3des=1
+
+	// Go 1.22 changed the default TLS cipher suites used by clients and
+	// servers when not explicitly configured, removing the cipher suites
+	// which used RSA based key exchange. We revert this behavior to support
+	// retrieving certificates from older systems.
+	//
+	// NOTE: This has been confirmed as needed for Microsoft Windows Server
+	// 2012 R2 systems (covered by Azure Arc).
+	//
+	// See also:
+	//
+	//   - https://pkg.go.dev/crypto/tls#Config.CipherSuites
+	//   - https://github.com/golang/go/issues/63413
+	tlsrsakex=1
+)
+
 require (
 	github.com/atc0005/cert-payload v0.7.1
 	github.com/atc0005/go-nagios v0.19.0


### PR DESCRIPTION
## Changes

- update `go.mod` to explicitly set `godebug` values to match behavior of earlier Go versions
  - enable 3DES cipher suites
  - enable cipher suites which use RSA based key exchange
- update `internal/netutils` package
  - update `netutils.GetCerts` func to explicitly set minimum TLS version as TLS 1.0
  - update `netutils.GetCerts` func to explicitly set ALL supported ciphers as candidates for TLS connections
  - add exported `netutils.SupportedCipherSuiteIDs` helper func

## References

- fixes GH-252