### PR TITLE
Fix invalid plugin size metric output

### DIFF
--- a/cmd/check_cert/main.go
+++ b/cmd/check_cert/main.go
@@ -27,8 +27,6 @@ func main() {
 
 	plugin := nagios.NewPlugin()
 
-	plugin.EnablePluginOutputSizePerfDataMetric()
-
 	// Override default section headers with our custom values.
 	plugin.SetErrorsLabel("VALIDATION ERRORS")
 	plugin.SetDetailedInfoLabel("VALIDATION CHECKS REPORT")
@@ -63,6 +61,8 @@ func main() {
 
 		return
 	}
+
+	plugin.EnablePluginOutputSizePerfDataMetric()
 
 	// Enable this setting *after* we initialize the plugin configuration;
 	// Debug level is the default global logging level which our initialized


### PR DESCRIPTION
Delay collection of output size perfdata metric until after config initialization.

- fixes GH-233