### PR TITLE
go.mod: update minimum Go version to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/atc0005/check-cert
 
-go 1.23.0
+go 1.25.0
 
 godebug (
 	// Go 1.23 changed the default TLS cipher suites used by clients and


### PR DESCRIPTION
## Overview

The Go project now unconditionally updates the minimum Go version for
`golang.org/x/` dependencies to be at least `1.(N-1).0`, where Go `1.N` is
the most recent major Go release, and Go `1.(N-1)` is the previous major
Go release.

Since this project uses dependencies associated with `golang.org/x`
repositories this project's go.mod file is also updated to reflect
the new minimum Go version.

## Changes

1. `go get go@1.25.0`
2. `go mod tidy`
3. `go mod vendor`
4. `go fix ./...`
5. `go mod edit -toolchain=none`

## References

> all: upgrade go directive to at least 1.25.0 [generated]
>
> By now Go 1.26.0 has been released, and Go 1.24 is no longer supported
> per the Go Release Policy (see https://go.dev/doc/devel/release#policy).
>
> See go.dev/doc/godebug#go-125 for GODEBUG changes relevant to Go 1.25.
>
> For golang/go#69095.

See also:

- golang/crypto@cab0f718548e8a858701b7b48161f44748532f58
- golang/sys@7548802db4d5a4f3948dbaf10cb2c27ddaf8495e
