### PR TITLE
Apply staticcheck quickfix QF1002

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -1262,15 +1262,15 @@ func verifySignature(issuedCert *x509.Certificate, issuerCert *x509.Certificate)
 	// Handle verification of signature algorithms no longer supported by
 	// current Go releases (declared insecure).
 	case errors.Is(sigVerifyErr, x509.InsecureAlgorithmError(issuedCert.SignatureAlgorithm)):
-		switch {
-		case issuedCert.SignatureAlgorithm == x509.MD5WithRSA:
+		switch issuedCert.SignatureAlgorithm {
+		case x509.MD5WithRSA:
 			return verifySignatureMD5WithRSA(issuedCert, issuerCert)
 
-		case issuedCert.SignatureAlgorithm == x509.SHA1WithRSA:
+		case x509.SHA1WithRSA:
 			// https://github.com/golang/go/issues/41682
 			return verifySignatureSHA1WithRSA(issuedCert, issuerCert)
 
-		case issuedCert.SignatureAlgorithm == x509.ECDSAWithSHA1:
+		case x509.ECDSAWithSHA1:
 			// https://github.com/golang/go/issues/41682
 			return verifySignatureECDSAWithSHA1(issuedCert, issuerCert)
 
@@ -1753,20 +1753,20 @@ func HasWeakSignatureAlgorithm(cert *x509.Certificate, certChain []*x509.Certifi
 		return false
 	}
 
-	switch {
-	case cert.SignatureAlgorithm == x509.MD2WithRSA:
+	switch cert.SignatureAlgorithm {
+	case x509.MD2WithRSA:
 		return true
 
-	case cert.SignatureAlgorithm == x509.MD5WithRSA:
+	case x509.MD5WithRSA:
 		return true
 
-	case cert.SignatureAlgorithm == x509.SHA1WithRSA:
+	case x509.SHA1WithRSA:
 		return true
 
-	case cert.SignatureAlgorithm == x509.DSAWithSHA1:
+	case x509.DSAWithSHA1:
 		return true
 
-	case cert.SignatureAlgorithm == x509.ECDSAWithSHA1:
+	case x509.ECDSAWithSHA1:
 		return true
 
 	default:

--- a/internal/certs/validation-chain-order.go
+++ b/internal/certs/validation-chain-order.go
@@ -381,52 +381,32 @@ func (covr ChainOrderValidationResult) StatusDetail() string {
 
 	switch {
 	case errors.Is(covr.err, ErrMisorderedCertificateChain):
-		detail.WriteString(
-			fmt.Sprintf(
-				"A misordered certificate chain was found!%s",
-				nagios.CheckOutputEOL,
-			),
-		)
+		fmt.Fprintf(&detail, "A misordered certificate chain was found!%s",
+			nagios.CheckOutputEOL)
 
 		detail.WriteString(reorderChainAdvice(covr.certChain))
 
 	case errors.Is(covr.err, ErrIncompleteCertificateChain):
-		detail.WriteString(
-			fmt.Sprintf(
-				"An incomplete certificate chain was found (%d certs total).%s%s",
-				covr.TotalCerts(),
-				nagios.CheckOutputEOL,
-				nagios.CheckOutputEOL,
-			),
-		)
+		fmt.Fprintf(&detail, "An incomplete certificate chain was found (%d certs total).%s%s",
+			covr.TotalCerts(),
+			nagios.CheckOutputEOL,
+			nagios.CheckOutputEOL)
 
 		detail.WriteString(incompleteChainAdvice(covr.certChain))
 
 	// Catchall error handling
 	case covr.err != nil:
-		detail.WriteString(
-			fmt.Sprintf(
-				"An unexpected error occurred while performing %s validation!%s",
-				strings.ToLower(covr.CheckName()),
-				nagios.CheckOutputEOL,
-			),
-		)
+		fmt.Fprintf(&detail, "An unexpected error occurred while performing %s validation!%s",
+			strings.ToLower(covr.CheckName()),
+			nagios.CheckOutputEOL)
 
-		detail.WriteString(
-			fmt.Sprintf(
-				"Please report the following error and provide a copy of your certificate chain for evaluation (e.g., see cpcert tool in this project).%s%s",
-				nagios.CheckOutputEOL,
-				nagios.CheckOutputEOL,
-			),
-		)
+		fmt.Fprintf(&detail, "Please report the following error and provide a copy of your certificate chain for evaluation (e.g., see cpcert tool in this project).%s%s",
+			nagios.CheckOutputEOL,
+			nagios.CheckOutputEOL)
 
-		detail.WriteString(
-			fmt.Sprintf(
-				"Error: %q%s",
-				covr.err.Error(),
-				nagios.CheckOutputEOL,
-			),
-		)
+		fmt.Fprintf(&detail, "Error: %q%s",
+			covr.err.Error(),
+			nagios.CheckOutputEOL)
 
 	// Success / OK scenario
 	default:
@@ -531,15 +511,11 @@ func summarizeChainOrder(certChain []*x509.Certificate) string {
 
 	for idx, cert := range certChain {
 		chainPos := ChainPosition(cert, certChain)
-		chainOrderList.WriteString(
-			fmt.Sprintf(
-				template,
-				idx,
-				hostVal(cert),
-				chainPos,
-				nagios.CheckOutputEOL,
-			),
-		)
+		fmt.Fprintf(&chainOrderList, template,
+			idx,
+			hostVal(cert),
+			chainPos,
+			nagios.CheckOutputEOL)
 	}
 
 	return chainOrderList.String()
@@ -562,40 +538,24 @@ func reorderChainAdvice(certChain []*x509.Certificate) string {
 
 	var advice strings.Builder
 
-	advice.WriteString(
-		fmt.Sprintf(
-			"This issue is often caused by using the incorrect intermediates bundle (with reversed entries).%s",
-			nagios.CheckOutputEOL,
-		),
-	)
+	fmt.Fprintf(&advice, "This issue is often caused by using the incorrect intermediates bundle (with reversed entries).%s",
+		nagios.CheckOutputEOL)
 
-	advice.WriteString(
-		fmt.Sprintf(
-			"It is recommended that you reorder the certificate chain to resolve this issue.%s%s",
-			nagios.CheckOutputEOL,
-			nagios.CheckOutputEOL,
-		),
-	)
+	fmt.Fprintf(&advice, "It is recommended that you reorder the certificate chain to resolve this issue.%s%s",
+		nagios.CheckOutputEOL,
+		nagios.CheckOutputEOL)
 
-	advice.WriteString(
-		fmt.Sprintf(
-			"Current chain order:%s%s%s%s",
-			nagios.CheckOutputEOL,
-			nagios.CheckOutputEOL,
-			summarizeChainOrder(certChain),
-			nagios.CheckOutputEOL,
-		),
-	)
+	fmt.Fprintf(&advice, "Current chain order:%s%s%s%s",
+		nagios.CheckOutputEOL,
+		nagios.CheckOutputEOL,
+		summarizeChainOrder(certChain),
+		nagios.CheckOutputEOL)
 
-	advice.WriteString(
-		fmt.Sprintf(
-			"Recommended chain order:%s%s%s%s",
-			nagios.CheckOutputEOL,
-			nagios.CheckOutputEOL,
-			summarizeFixedChainOrder(certChain),
-			nagios.CheckOutputEOL,
-		),
-	)
+	fmt.Fprintf(&advice, "Recommended chain order:%s%s%s%s",
+		nagios.CheckOutputEOL,
+		nagios.CheckOutputEOL,
+		summarizeFixedChainOrder(certChain),
+		nagios.CheckOutputEOL)
 
 	advice.WriteString(certDownloadLinksAdvice(certChain))
 

--- a/internal/certs/validation-helpers.go
+++ b/internal/certs/validation-helpers.go
@@ -24,12 +24,8 @@ func incompleteChainAdvice(certChain []*x509.Certificate) string {
 
 	var advice strings.Builder
 
-	advice.WriteString(
-		fmt.Sprintf(
-			"This issue often occurs with Windows Servers when (newer) intermediates are missing from the certificate stores.%s",
-			nagios.CheckOutputEOL,
-		),
-	)
+	fmt.Fprintf(&advice, "This issue often occurs with Windows Servers when (newer) intermediates are missing from the certificate stores.%s",
+		nagios.CheckOutputEOL)
 
 	hostValRef := func(chain []*x509.Certificate) string {
 		switch {
@@ -57,13 +53,9 @@ func incompleteChainAdvice(certChain []*x509.Certificate) string {
 
 	switch {
 	case firstCertType == certChainPositionLeafSelfSigned:
-		advice.WriteString(
-			fmt.Sprintf(
-				"It is recommended that you replace the %s certificate with a valid certificate chain.%s",
-				certChainPositionLeafSelfSigned,
-				nagios.CheckOutputEOL,
-			),
-		)
+		fmt.Fprintf(&advice, "It is recommended that you replace the %s certificate with a valid certificate chain.%s",
+			certChainPositionLeafSelfSigned,
+			nagios.CheckOutputEOL)
 
 		// TODO: We'd need to consider how this advice would come across for a
 		// cert check which monitors an intermediates bundle; intermediate
@@ -81,13 +73,9 @@ func incompleteChainAdvice(certChain []*x509.Certificate) string {
 		// 		advice.WriteString(certDownloadLinksAdvice(certChain))
 
 	case isMissingIntermediates:
-		advice.WriteString(
-			fmt.Sprintf(
-				"It is recommended that you configure the service%sto include the missing intermediates.%s",
-				hostValRef(certChain),
-				nagios.CheckOutputEOL,
-			),
-		)
+		fmt.Fprintf(&advice, "It is recommended that you configure the service%sto include the missing intermediates.%s",
+			hostValRef(certChain),
+			nagios.CheckOutputEOL)
 
 		advice.WriteString(certDownloadLinksAdvice(certChain))
 
@@ -152,14 +140,10 @@ outerLoop:
 				)
 
 				if issuerContainsCAPrefix || issuedContainsCAPrefix {
-					advice.WriteString(
-						fmt.Sprintf(
-							"%s%s%s",
-							nagios.CheckOutputEOL,
-							adviceEntry.Advice,
-							nagios.CheckOutputEOL,
-						),
-					)
+					fmt.Fprintf(&advice, "%s%s%s",
+						nagios.CheckOutputEOL,
+						adviceEntry.Advice,
+						nagios.CheckOutputEOL)
 
 					break outerLoop
 				}

--- a/internal/certs/validation-hostname.go
+++ b/internal/certs/validation-hostname.go
@@ -549,8 +549,8 @@ func (hnvr HostnameValidationResult) String() string {
 func (hnvr HostnameValidationResult) Report() string {
 
 	detail := hnvr.StatusDetail()
-	switch {
-	case detail == "":
+	switch detail {
+	case "":
 		return fmt.Sprintf(
 			"%s %s",
 			hnvr.Status(),

--- a/internal/certs/validation-root.go
+++ b/internal/certs/validation-root.go
@@ -316,49 +316,29 @@ func (rvr RootValidationResult) StatusDetail() string {
 
 	switch {
 	case errors.Is(rvr.err, ErrRootCertsFound):
-		detail.WriteString(
-			fmt.Sprintf(
-				"A root certificate in the chain was found!%s",
-				nagios.CheckOutputEOL,
-			),
-		)
+		fmt.Fprintf(&detail, "A root certificate in the chain was found!%s",
+			nagios.CheckOutputEOL)
 
-		detail.WriteString(
-			fmt.Sprintf(
-				"%s%s%s",
-				nagios.CheckOutputEOL,
-				strings.TrimSpace(rootCertFoundAdvice),
-				nagios.CheckOutputEOL,
-			),
-		)
+		fmt.Fprintf(&detail, "%s%s%s",
+			nagios.CheckOutputEOL,
+			strings.TrimSpace(rootCertFoundAdvice),
+			nagios.CheckOutputEOL)
 
 		// detail.WriteString(reorderChainAdvice(rvr.certChain))
 
 	// Catchall error handling
 	case rvr.err != nil:
-		detail.WriteString(
-			fmt.Sprintf(
-				"An unexpected error occurred while performing %s validation!%s",
-				strings.ToLower(rvr.CheckName()),
-				nagios.CheckOutputEOL,
-			),
-		)
+		fmt.Fprintf(&detail, "An unexpected error occurred while performing %s validation!%s",
+			strings.ToLower(rvr.CheckName()),
+			nagios.CheckOutputEOL)
 
-		detail.WriteString(
-			fmt.Sprintf(
-				"Please report the following error and provide a copy of your certificate chain for evaluation (e.g., see cpcert tool in this project).%s%s",
-				nagios.CheckOutputEOL,
-				nagios.CheckOutputEOL,
-			),
-		)
+		fmt.Fprintf(&detail, "Please report the following error and provide a copy of your certificate chain for evaluation (e.g., see cpcert tool in this project).%s%s",
+			nagios.CheckOutputEOL,
+			nagios.CheckOutputEOL)
 
-		detail.WriteString(
-			fmt.Sprintf(
-				"Error: %q%s",
-				rvr.err.Error(),
-				nagios.CheckOutputEOL,
-			),
-		)
+		fmt.Fprintf(&detail, "Error: %q%s",
+			rvr.err.Error(),
+			nagios.CheckOutputEOL)
 
 	// Success / OK scenario
 	default:

--- a/internal/certs/validation-sans.go
+++ b/internal/certs/validation-sans.go
@@ -468,8 +468,8 @@ func (slvr SANsListValidationResult) String() string {
 func (slvr SANsListValidationResult) Report() string {
 
 	detail := slvr.StatusDetail()
-	switch {
-	case detail == "":
+	switch detail {
+	case "":
 		return fmt.Sprintf(
 			"%s %s",
 			slvr.Status(),


### PR DESCRIPTION
The following quickfix automatic refactoring was applied to simplify existing code:

- `QF1002: could use tagged switch on ...`

This refactoring was applied via:

```
golangci-lint-v2 run \
    --no-config \
    --enable-only=staticcheck \
    --fix \
    ./...
```

golangci-lint v2.11.3 was used to apply these changes.