### PR TITLE
Apply staticcheck quickfix QF1002

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -996,15 +996,15 @@ func verifySignature(issuedCert *x509.Certificate, issuerCert *x509.Certificate)
 	// Handle verification of signature algorithms no longer supported by
 	// current Go releases (declared insecure).
 	case errors.Is(sigVerifyErr, x509.InsecureAlgorithmError(issuedCert.SignatureAlgorithm)):
-		switch {
-		case issuedCert.SignatureAlgorithm == x509.MD5WithRSA:
+		switch issuedCert.SignatureAlgorithm {
+		case x509.MD5WithRSA:
 			return verifySignatureMD5WithRSA(issuedCert, issuerCert)
 
-		case issuedCert.SignatureAlgorithm == x509.SHA1WithRSA:
+		case x509.SHA1WithRSA:
 			// https://github.com/golang/go/issues/41682
 			return verifySignatureSHA1WithRSA(issuedCert, issuerCert)
 
-		case issuedCert.SignatureAlgorithm == x509.ECDSAWithSHA1:
+		case x509.ECDSAWithSHA1:
 			// https://github.com/golang/go/issues/41682
 			return verifySignatureECDSAWithSHA1(issuedCert, issuerCert)
 
@@ -1487,20 +1487,20 @@ func HasWeakSignatureAlgorithm(cert *x509.Certificate, certChain []*x509.Certifi
 		return false
 	}
 
-	switch {
-	case cert.SignatureAlgorithm == x509.MD2WithRSA:
+	switch cert.SignatureAlgorithm {
+	case x509.MD2WithRSA:
 		return true
 
-	case cert.SignatureAlgorithm == x509.MD5WithRSA:
+	case x509.MD5WithRSA:
 		return true
 
-	case cert.SignatureAlgorithm == x509.SHA1WithRSA:
+	case x509.SHA1WithRSA:
 		return true
 
-	case cert.SignatureAlgorithm == x509.DSAWithSHA1:
+	case x509.DSAWithSHA1:
 		return true
 
-	case cert.SignatureAlgorithm == x509.ECDSAWithSHA1:
+	case x509.ECDSAWithSHA1:
 		return true
 
 	default:

--- a/internal/certs/validation-hostname.go
+++ b/internal/certs/validation-hostname.go
@@ -525,8 +525,8 @@ func (hnvr HostnameValidationResult) String() string {
 func (hnvr HostnameValidationResult) Report() string {
 
 	detail := hnvr.StatusDetail()
-	switch {
-	case detail == "":
+	switch detail {
+	case "":
 		return fmt.Sprintf(
 			"%s %s",
 			hnvr.Status(),

--- a/internal/certs/validation-sans.go
+++ b/internal/certs/validation-sans.go
@@ -428,8 +428,8 @@ func (slvr SANsListValidationResult) String() string {
 func (slvr SANsListValidationResult) Report() string {
 
 	detail := slvr.StatusDetail()
-	switch {
-	case detail == "":
+	switch detail {
+	case "":
 		return fmt.Sprintf(
 			"%s %s",
 			slvr.Status(),


### PR DESCRIPTION
The following quickfix automatic refactoring was applied to simplify existing code:

- `QF1002: could use tagged switch on ...`

This refactoring was applied via:

```
golangci-lint-v2 run \
    --no-config \
    --enable-only=staticcheck \
    --fix \
    ./...
```

golangci-lint v2.11.3 was used to apply these changes.